### PR TITLE
feat: add check for orchestrations

### DIFF
--- a/common/types/errors.go
+++ b/common/types/errors.go
@@ -127,3 +127,7 @@ func IsFatal(err error) bool {
 	var fatalErr FatalError
 	return errors.As(err, &fatalErr) && fatalErr.IsFatal()
 }
+
+func NewValidationError(path string, message string) error {
+	return BadRequestError{Message: fmt.Sprintf("Validation error at path [%s]: %s", path, message)}
+}

--- a/pmanager/api/store.go
+++ b/pmanager/api/store.go
@@ -49,13 +49,13 @@ type DefinitionStore interface {
 	// ExistsActivityDefinition returns true if an ActivityDefinition exists for the given type.
 	ExistsActivityDefinition(ctx context.Context, activityType ActivityType) (bool, error)
 
-	// StoreOrchestrationDefinition saves or updates a OrchestrationDefinition
+	// StoreOrchestrationDefinition saves or updates an OrchestrationDefinition
 	StoreOrchestrationDefinition(ctx context.Context, definition *OrchestrationDefinition) (*OrchestrationDefinition, error)
 
-	// StoreActivityDefinition saves or updates a ActivityDefinition
+	// StoreActivityDefinition saves or updates an ActivityDefinition
 	StoreActivityDefinition(ctx context.Context, definition *ActivityDefinition) (*ActivityDefinition, error)
 
-	// DeleteOrchestrationDefinition removes a OrchestrationDefinition for the given type, returning true if successful.
+	// DeleteOrchestrationDefinition removes an OrchestrationDefinition for the given type, returning true if successful.
 	DeleteOrchestrationDefinition(ctx context.Context, orchestrationType model.OrchestrationType) (bool, error)
 
 	ActivityDefinitionReferences(ctx context.Context, activityType ActivityType) ([]string, error)
@@ -78,6 +78,7 @@ type OrchestrationEntry struct {
 	StateTimestamp    time.Time               `json:"stateTimestamp"`
 	CreatedTimestamp  time.Time               `json:"createdTimestamp"`
 	OrchestrationType model.OrchestrationType `json:"orchestrationType"`
+	DefinitionID      string                  `json:"definitionId"`
 }
 
 func (o *OrchestrationEntry) GetID() string {

--- a/pmanager/api/types_instantiate_test.go
+++ b/pmanager/api/types_instantiate_test.go
@@ -42,7 +42,7 @@ func TestInstantiateOrchestration(t *testing.T) {
 			"key2": 42,
 		}
 
-		orchestration, err := InstantiateOrchestration(orchestrationID, "123", model.VPADeployType, definition, data)
+		orchestration, err := InstantiateOrchestration(orchestrationID, "123", model.VPADeployType, "test-definition-id", definition, data)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, orchestration)
@@ -89,7 +89,7 @@ func TestInstantiateOrchestration(t *testing.T) {
 		}
 		data := map[string]any{"test": "data"}
 
-		orchestration, err := InstantiateOrchestration(orchestrationID, "123", model.VPADeployType, definition, data)
+		orchestration, err := InstantiateOrchestration(orchestrationID, "123", model.VPADeployType, "some-definition-id", definition, data)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, orchestration)
@@ -144,7 +144,7 @@ func TestInstantiateOrchestration(t *testing.T) {
 		}
 		data := map[string]any{"parallel": "test"}
 
-		orchestration, err := InstantiateOrchestration(orchestrationID, "123", model.VPADeployType, definition, data)
+		orchestration, err := InstantiateOrchestration(orchestrationID, "123", model.VPADeployType, "test-definition-id", definition, data)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, orchestration)
@@ -175,7 +175,7 @@ func TestInstantiateOrchestration(t *testing.T) {
 
 	t.Run("error when cycle detected", func(t *testing.T) {
 		orchestrationID := "test-orchestration-cycle"
-		definition := []Activity{
+		activities := []Activity{
 			{
 				ID:        "activity1",
 				Type:      "first",
@@ -191,7 +191,7 @@ func TestInstantiateOrchestration(t *testing.T) {
 		}
 		data := map[string]any{"cycle": "test"}
 
-		orchestration, err := InstantiateOrchestration(orchestrationID, "123", model.VPADeployType, definition, data)
+		orchestration, err := InstantiateOrchestration(orchestrationID, "123", model.VPADeployType, "test-definition-id", activities, data)
 
 		assert.Error(t, err)
 		assert.Nil(t, orchestration)
@@ -200,10 +200,10 @@ func TestInstantiateOrchestration(t *testing.T) {
 
 	t.Run("successful instantiation with empty definition", func(t *testing.T) {
 		orchestrationID := "test-orchestration-empty"
-		definition := []Activity{}
+		var activities []Activity
 		data := map[string]any{"empty": "test"}
 
-		orchestration, err := InstantiateOrchestration(orchestrationID, "123", model.VPADeployType, definition, data)
+		orchestration, err := InstantiateOrchestration(orchestrationID, "123", model.VPADeployType, "test-activities-id", activities, data)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, orchestration)
@@ -214,7 +214,7 @@ func TestInstantiateOrchestration(t *testing.T) {
 
 	t.Run("successful instantiation with nil data", func(t *testing.T) {
 		orchestrationID := "test-orchestration-nil-data"
-		definition := []Activity{
+		activities := []Activity{
 			{
 				ID:        "activity1",
 				Type:      "test",
@@ -223,7 +223,7 @@ func TestInstantiateOrchestration(t *testing.T) {
 			},
 		}
 
-		orchestration, err := InstantiateOrchestration(orchestrationID, "123", model.VPADeployType, definition, nil)
+		orchestration, err := InstantiateOrchestration(orchestrationID, "123", model.VPADeployType, "test-definition-id", activities, nil)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, orchestration)
@@ -239,7 +239,7 @@ func TestInstantiateOrchestration(t *testing.T) {
 
 	t.Run("successful instantiation with complex dependencies", func(t *testing.T) {
 		orchestrationID := "test-orchestration-complex"
-		definition := []Activity{
+		activities := []Activity{
 			{
 				ID:        "activity1",
 				Type:      "init",
@@ -278,7 +278,7 @@ func TestInstantiateOrchestration(t *testing.T) {
 			},
 		}
 
-		orchestration, err := InstantiateOrchestration(orchestrationID, "123", model.VPADeployType, definition, data)
+		orchestration, err := InstantiateOrchestration(orchestrationID, "123", model.VPADeployType, "test-activities-id", activities, data)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, orchestration)
@@ -325,7 +325,7 @@ func TestInstantiateOrchestration(t *testing.T) {
 
 	t.Run("uses orchestration ID", func(t *testing.T) {
 		orchestrationID := "test-orchestration-id"
-		definition := []Activity{
+		activities := []Activity{
 			{
 				ID:        "activity1",
 				Type:      "test",
@@ -335,7 +335,7 @@ func TestInstantiateOrchestration(t *testing.T) {
 		}
 		data := map[string]any{"test": "data"}
 
-		orchestration, err1 := InstantiateOrchestration(orchestrationID, "123", model.VPADeployType, definition, data)
+		orchestration, err1 := InstantiateOrchestration(orchestrationID, "123", model.VPADeployType, "test-activities-id", activities, data)
 
 		assert.NoError(t, err1)
 		assert.NotNil(t, orchestration)
@@ -344,7 +344,7 @@ func TestInstantiateOrchestration(t *testing.T) {
 
 	t.Run("error with invalid dependency reference", func(t *testing.T) {
 		orchestrationID := "test-orchestration-invalid-dep"
-		definition := []Activity{
+		activities := []Activity{
 			{
 				ID:        "activity1",
 				Type:      "test",
@@ -354,7 +354,7 @@ func TestInstantiateOrchestration(t *testing.T) {
 		}
 		data := map[string]any{"test": "data"}
 
-		orchestration, err := InstantiateOrchestration(orchestrationID, "123", model.VPADeployType, definition, data)
+		orchestration, err := InstantiateOrchestration(orchestrationID, "123", model.VPADeployType, "test-activities-id", activities, data)
 
 		assert.Error(t, err)
 		assert.Nil(t, orchestration)

--- a/pmanager/core/assembly.go
+++ b/pmanager/core/assembly.go
@@ -37,6 +37,7 @@ func (m PMCoreServiceAssembly) Requires() []system.ServiceType {
 func (m PMCoreServiceAssembly) Init(context *system.InitContext) error {
 	definitionStore := context.Registry.Resolve(api.DefinitionStoreKey).(api.DefinitionStore)
 	transactionContext := context.Registry.Resolve(store.TransactionContextKey).(store.TransactionContext)
+	orchestrationIndex := context.Registry.Resolve(api.OrchestrationIndexKey).(store.EntityStore[*api.OrchestrationEntry])
 
 	context.Registry.Register(api.ProvisionManagerKey, provisionManager{
 		orchestrator: context.Registry.Resolve(api.OrchestratorKey).(api.Orchestrator),
@@ -47,8 +48,9 @@ func (m PMCoreServiceAssembly) Init(context *system.InitContext) error {
 	})
 
 	context.Registry.Register(api.DefinitionManagerKey, definitionManager{
-		trxContext: transactionContext,
-		store:      definitionStore,
+		trxContext:         transactionContext,
+		store:              definitionStore,
+		orchestrationStore: orchestrationIndex,
 	})
 	return nil
 }

--- a/pmanager/core/provision.go
+++ b/pmanager/core/provision.go
@@ -69,7 +69,7 @@ func (p provisionManager) Start(ctx context.Context, manifest *model.Orchestrati
 		}
 
 		// Does not exist, create the orchestration
-		orch, err = api.InstantiateOrchestration(manifest.ID, manifest.CorrelationID, manifest.OrchestrationType, definition.Activities, manifest.Payload)
+		orch, err = api.InstantiateOrchestration(manifest.ID, manifest.CorrelationID, manifest.OrchestrationType, definition.GetID(), definition.Activities, manifest.Payload)
 		if err != nil {
 			return types.NewFatalWrappedError(err, "error instantiating orchestration for %s", manifestID)
 		}

--- a/pmanager/model/v1alpha1/model.go
+++ b/pmanager/model/v1alpha1/model.go
@@ -67,11 +67,13 @@ type OrchestrationEntry struct {
 	StateTimestamp    time.Time               `json:"stateTimestamp"`
 	CreatedTimestamp  time.Time               `json:"createdTimestamp"`
 	OrchestrationType model.OrchestrationType `json:"orchestrationType"`
+	DefinitionID      string                  `json:"definitionId"`
 }
 
 type Orchestration struct {
 	ID                string                  `json:"id"`
 	CorrelationID     string                  `json:"correlationId"`
+	DefinitionID      string                  `json:"definitionId"`
 	State             int                     `json:"state"`
 	StateTimestamp    time.Time               `json:"stateTimestamp"`
 	CreatedTimestamp  time.Time               `json:"createdTimestamp"`

--- a/pmanager/model/v1alpha1/transformers.go
+++ b/pmanager/model/v1alpha1/transformers.go
@@ -149,6 +149,7 @@ func ToOrchestrationEntry(entry *api.OrchestrationEntry) OrchestrationEntry {
 	return OrchestrationEntry{
 		ID:                entry.ID,
 		CorrelationID:     entry.CorrelationID,
+		DefinitionID:      entry.DefinitionID,
 		State:             int(entry.State),
 		StateTimestamp:    entry.StateTimestamp,
 		CreatedTimestamp:  entry.CreatedTimestamp,
@@ -160,6 +161,7 @@ func ToOrchestration(orchestration *api.Orchestration) Orchestration {
 	return Orchestration{
 		ID:                orchestration.ID,
 		CorrelationID:     orchestration.CorrelationID,
+		DefinitionID:      orchestration.DefinitionID,
 		State:             int(orchestration.State),
 		StateTimestamp:    orchestration.StateTimestamp,
 		CreatedTimestamp:  orchestration.CreatedTimestamp,

--- a/pmanager/sqlstore/orchestration_test.go
+++ b/pmanager/sqlstore/orchestration_test.go
@@ -46,6 +46,7 @@ func TestNewOrchestrationEntryStore_FindByID_Success(t *testing.T) {
 		ID:                "orch-entry-1",
 		Version:           1,
 		CorrelationID:     "correlation-abc-123",
+		DefinitionID:      "def-1",
 		State:             api.OrchestrationStateInitialized,
 		StateTimestamp:    time.Now(),
 		CreatedTimestamp:  time.Now(),
@@ -53,10 +54,11 @@ func TestNewOrchestrationEntryStore_FindByID_Success(t *testing.T) {
 	}
 
 	_, err := testDB.Exec(
-		"INSERT INTO orchestration_entries (id, version, correlation_id, state, state_timestamp, created_timestamp, orchestration_type) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+		"INSERT INTO orchestration_entries (id, version, correlation_id, definition_id, state, state_timestamp, created_timestamp, orchestration_type) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
 		entry.ID,
 		entry.Version,
 		entry.CorrelationID,
+		entry.DefinitionID,
 		entry.State,
 		entry.StateTimestamp,
 		entry.CreatedTimestamp,
@@ -178,10 +180,11 @@ func TestNewOrchestrationEntryStore_SearchByStatePredicate(t *testing.T) {
 
 	for _, entry := range entries {
 		_, err := testDB.Exec(
-			"INSERT INTO orchestration_entries (id, version, correlation_id, state, state_timestamp, created_timestamp, orchestration_type) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+			"INSERT INTO orchestration_entries (id, version, correlation_id, definition_id, state, state_timestamp, created_timestamp, orchestration_type) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
 			entry.ID,
 			entry.Version,
 			entry.CorrelationID,
+			entry.DefinitionID,
 			entry.State,
 			entry.StateTimestamp,
 			entry.CreatedTimestamp,
@@ -223,6 +226,7 @@ func TestNewOrchestrationEntryStore_SearchByCorrelationIDPredicate(t *testing.T)
 			ID:                "orch-corr-1",
 			Version:           1,
 			CorrelationID:     "correlation-001",
+			DefinitionID:      "definition-001",
 			State:             api.OrchestrationStateInitialized,
 			StateTimestamp:    time.Now(),
 			CreatedTimestamp:  time.Now(),
@@ -232,6 +236,7 @@ func TestNewOrchestrationEntryStore_SearchByCorrelationIDPredicate(t *testing.T)
 			ID:                "orch-corr-2",
 			Version:           1,
 			CorrelationID:     "correlation-002",
+			DefinitionID:      "definition-002",
 			State:             api.OrchestrationStateRunning,
 			StateTimestamp:    time.Now(),
 			CreatedTimestamp:  time.Now(),
@@ -241,6 +246,7 @@ func TestNewOrchestrationEntryStore_SearchByCorrelationIDPredicate(t *testing.T)
 			ID:                "orch-corr-3",
 			Version:           1,
 			CorrelationID:     "correlation-001",
+			DefinitionID:      "definition-001",
 			State:             api.OrchestrationStateCompleted,
 			StateTimestamp:    time.Now(),
 			CreatedTimestamp:  time.Now(),
@@ -250,6 +256,7 @@ func TestNewOrchestrationEntryStore_SearchByCorrelationIDPredicate(t *testing.T)
 			ID:                "orch-corr-4",
 			Version:           1,
 			CorrelationID:     "correlation-003",
+			DefinitionID:      "definition-003",
 			State:             api.OrchestrationStateRunning,
 			StateTimestamp:    time.Now(),
 			CreatedTimestamp:  time.Now(),
@@ -259,10 +266,11 @@ func TestNewOrchestrationEntryStore_SearchByCorrelationIDPredicate(t *testing.T)
 
 	for _, entry := range entries {
 		_, err := testDB.Exec(
-			"INSERT INTO orchestration_entries (id, version, correlation_id, state, state_timestamp, created_timestamp, orchestration_type) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+			"INSERT INTO orchestration_entries (id, version, correlation_id, definition_id, state, state_timestamp, created_timestamp, orchestration_type) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
 			entry.ID,
 			entry.Version,
 			entry.CorrelationID,
+			entry.DefinitionID,
 			entry.State,
 			entry.StateTimestamp,
 			entry.CreatedTimestamp,
@@ -304,6 +312,7 @@ func TestNewOrchestrationEntryStore_SearchByStateAndCorrelationIDPredicate(t *te
 			ID:                "orch-comb-1",
 			Version:           1,
 			CorrelationID:     "correlation-combined-1",
+			DefinitionID:      "definition-combined-1",
 			State:             api.OrchestrationStateRunning,
 			StateTimestamp:    time.Now(),
 			CreatedTimestamp:  time.Now(),
@@ -313,6 +322,7 @@ func TestNewOrchestrationEntryStore_SearchByStateAndCorrelationIDPredicate(t *te
 			ID:                "orch-comb-2",
 			Version:           1,
 			CorrelationID:     "correlation-combined-1",
+			DefinitionID:      "definition-combined-2",
 			State:             api.OrchestrationStateCompleted,
 			StateTimestamp:    time.Now(),
 			CreatedTimestamp:  time.Now(),
@@ -322,6 +332,7 @@ func TestNewOrchestrationEntryStore_SearchByStateAndCorrelationIDPredicate(t *te
 			ID:                "orch-comb-3",
 			Version:           1,
 			CorrelationID:     "correlation-combined-2",
+			DefinitionID:      "definition-combined-2",
 			State:             api.OrchestrationStateRunning,
 			StateTimestamp:    time.Now(),
 			CreatedTimestamp:  time.Now(),
@@ -331,6 +342,7 @@ func TestNewOrchestrationEntryStore_SearchByStateAndCorrelationIDPredicate(t *te
 			ID:                "orch-comb-4",
 			Version:           1,
 			CorrelationID:     "correlation-combined-1",
+			DefinitionID:      "definition-combined-1",
 			State:             api.OrchestrationStateInitialized,
 			StateTimestamp:    time.Now(),
 			CreatedTimestamp:  time.Now(),
@@ -340,10 +352,11 @@ func TestNewOrchestrationEntryStore_SearchByStateAndCorrelationIDPredicate(t *te
 
 	for _, entry := range entries {
 		_, err := testDB.Exec(
-			"INSERT INTO orchestration_entries (id, version, correlation_id, state, created_timestamp, state_timestamp, orchestration_type) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+			"INSERT INTO orchestration_entries (id, version, correlation_id, definition_id, state, created_timestamp, state_timestamp, orchestration_type) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
 			entry.ID,
 			entry.Version,
 			entry.CorrelationID,
+			entry.DefinitionID,
 			entry.State,
 			entry.StateTimestamp,
 			entry.CreatedTimestamp,

--- a/pmanager/sqlstore/tables.go
+++ b/pmanager/sqlstore/tables.go
@@ -31,6 +31,7 @@ func createOrchestrationEntriesTable(db *sql.DB) error {
 			id VARCHAR(255) PRIMARY KEY,
 			version BIGINT NOT NULL,
 			correlation_id VARCHAR(255) NOT NULL ,
+		    definition_id VARCHAR(255) NOT NULL,
 			"state" INTEGER,
 			state_timestamp TIMESTAMP NOT NULL ,
 			created_timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/tmanager/core/service_participant_test.go
+++ b/tmanager/core/service_participant_test.go
@@ -627,8 +627,8 @@ func TestGetFilteredProfiles(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(result))
-		assert.Equal(t, "ds-1", result[0].ID)
-		assert.Equal(t, "ds-2", result[1].ID)
+
+		require.ElementsMatch(t, []string{"ds-1", "ds-2"}, []string{result[0].ID, result[1].ID})
 	})
 
 	t.Run("filters profiles by specified IDs", func(t *testing.T) {


### PR DESCRIPTION
This PR adds a check that disallows the deletion of `OrchestrationDefinition` objects if >=1 `Orchestration` objects have been created for them. 

To do that, the `Orchestration` type now has the `DefinitionID` property which points back to the orchestration definition.
