### PR TITLE
fix: remove unused httpClientServiceAssembly from pmanager

### DIFF
--- a/pmanager/cmd/server/launcher/launcher.go
+++ b/pmanager/cmd/server/launcher/launcher.go
@@ -15,7 +15,6 @@ package launcher
 import (
 	"fmt"
 
-	"github.com/eclipse-cfm/cfm/assembly/httpclient"
 	"github.com/eclipse-cfm/cfm/assembly/routing"
 	"github.com/eclipse-cfm/cfm/common/runtime"
 	"github.com/eclipse-cfm/cfm/common/store"


### PR DESCRIPTION
## Summary
- Removes the unused `httpClientServiceAssembly` registration from the pmanager launcher
- The `HttpClient` is only used by agents (edcv, keycloak, registration, onboarding), not by pmanager services
- Can be re-added if needed in the future

Closes #42

## Test plan
- [x] `go build ./pmanager/...` compiles successfully
- [x] Full test suite passes (`go test ./common/... ./pmanager/... ./tmanager/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)