### PR TITLE
fix: allow empty predicate in query APIs

### DIFF
--- a/common/model/model.go
+++ b/common/model/model.go
@@ -86,7 +86,7 @@ func (dt VPAType) String() string {
 }
 
 type Query struct {
-	Predicate string `json:"predicate" required:"true"`
+	Predicate string `json:"predicate"`
 	Offset    int64  `json:"offset"`
 	Limit     int64  `json:"limit"`
 }

--- a/common/query/parser.go
+++ b/common/query/parser.go
@@ -23,7 +23,12 @@ import (
 // ParsePredicate parses a predicate string according to the grammar defined in Query.g4.
 // This function builds the predicate structure based on the ANTLR parse tree.
 // NOTE if the ANTLR grammar changes, the visiting logic in predicateBuilder will need to be updated.
+// An empty or whitespace-only input is treated as a match-all predicate (no filter).
 func ParsePredicate(input string) (Predicate, error) {
+	if strings.TrimSpace(input) == "" {
+		return &MatchAllPredicate{}, nil
+	}
+
 	is := antlr.NewInputStream(input)
 	lexer := NewQueryLexer(is)
 	stream := antlr.NewCommonTokenStream(lexer, 0)

--- a/common/query/parser_test.go
+++ b/common/query/parser_test.go
@@ -421,32 +421,42 @@ func TestParse_CaseInsensitiveKeywords(t *testing.T) {
 // TestParse_EdgeCases tests edge cases and error handling
 func TestParse_EdgeCases(t *testing.T) {
 	tests := []struct {
-		name        string
-		input       string
-		expectError bool
+		name           string
+		input          string
+		expectError    bool
+		expectMatchAll bool
 	}{
 		{
-			name:        "Empty string",
-			input:       "",
-			expectError: true,
+			name:           "Empty string returns match-all",
+			input:          "",
+			expectError:    false,
+			expectMatchAll: true,
 		},
 		{
-			name:        "Whitespace only",
-			input:       "   ",
-			expectError: true,
+			name:           "Whitespace only returns match-all",
+			input:          "   ",
+			expectError:    false,
+			expectMatchAll: true,
 		},
 		{
-			name:        "Valid AND",
-			input:       "Name = 'Alice' AND Age > 25",
-			expectError: false,
+			name:           "Valid AND",
+			input:          "Name = 'Alice' AND Age > 25",
+			expectError:    false,
+			expectMatchAll: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := ParsePredicate(tt.input)
+			pred, err := ParsePredicate(tt.input)
 			if (err != nil) != tt.expectError {
 				t.Errorf("ParsePredicate() error = %v, expectError = %v", err, tt.expectError)
+				return
+			}
+			if tt.expectMatchAll {
+				if _, ok := pred.(*MatchAllPredicate); !ok {
+					t.Errorf("expected *MatchAllPredicate, got %T", pred)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Empty, whitespace-only, or omitted predicates are now treated as match-all filters instead of returning 400 errors
- `ParsePredicate` returns `MatchAllPredicate` for empty/whitespace input (early return before ANTLR parsing)
- Removed `required:"true"` tag from the `Predicate` field in the `Query` model
- Updated edge case tests to verify new behavior

Closes #15

## Test plan
- [x] `TestParse_EdgeCases` — empty string and whitespace return `MatchAllPredicate`
- [x] `TestParseTrueKeyword` — existing `true` keyword behavior preserved
- [x] Full test suite passes (`go test ./common/... ./pmanager/... ./tmanager/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)