### PR TITLE
build: add conventional commits enforcement via GitHub Action

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,36 @@
+name: Conventional Commits
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check PR title follows Conventional Commits"
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            chore
+            refactor
+            test
+            ci
+            build
+            perf
+            style
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            should start with a lowercase letter.


### PR DESCRIPTION
## Summary
- Adds a GitHub Action (`conventional-commits.yml`) that validates PR titles follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- Allowed types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `build`, `perf`, `style`
- Scopes are optional, subject must start lowercase
- Uses `amannn/action-semantic-pull-request@v5` (no Node.js dependencies needed)

Closes #8

## Test plan
- [x] Workflow file is valid YAML
- [x] PR titles like `feat: add feature` pass (verified: this PR's own title passed the check)
- [x] PR titles like `Add feature` (no type prefix) fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)