### PR TITLE
feat: set sane default values for API fields

### DIFF
--- a/tmanager/model/v1alpha1/model.go
+++ b/tmanager/model/v1alpha1/model.go
@@ -19,8 +19,8 @@ import (
 )
 
 type Entity struct {
-	ID      string `json:"id" required:"true"`
-	Version int64  `json:"version" required:"true"`
+	ID      string `json:"id"`
+	Version int64  `json:"version"`
 }
 
 type NewTenant struct {
@@ -34,8 +34,8 @@ type Tenant struct {
 
 type NewCell struct {
 	ExternalID     string         `json:"externalId"`
-	State          string         `json:"state" required:"true"`
-	StateTimestamp time.Time      `json:"stateTimestamp" required:"true"`
+	State          string         `json:"state,omitempty"`
+	StateTimestamp time.Time      `json:"stateTimestamp,omitempty"`
 	Properties     map[string]any `json:"properties,omitempty"`
 }
 
@@ -111,8 +111,8 @@ type VirtualParticipantAgent struct {
 
 type DeployableEntity struct {
 	Entity
-	State          string    `json:"state" required:"true"`
-	StateTimestamp time.Time `json:"stateTimestamp" required:"true"`
+	State          string    `json:"state"`
+	StateTimestamp time.Time `json:"stateTimestamp"`
 }
 
 type TenantPropertiesDiff struct {

--- a/tmanager/model/v1alpha1/transformers.go
+++ b/tmanager/model/v1alpha1/transformers.go
@@ -13,6 +13,8 @@
 package v1alpha1
 
 import (
+	"time"
+
 	"github.com/google/uuid"
 	"github.com/metaform/connector-fabric-manager/common/model"
 	"github.com/metaform/connector-fabric-manager/tmanager/api"
@@ -211,7 +213,18 @@ func ToAPICell(input *Cell) *api.Cell {
 }
 
 func NewAPICell(input *NewCell) *api.Cell {
-	state, _ := api.ToDeploymentState(input.State)
+	state := api.DeploymentStateInitial
+	if input.State != "" {
+		if parsed, err := api.ToDeploymentState(input.State); err == nil {
+			state = parsed
+		}
+	}
+
+	stateTimestamp := input.StateTimestamp
+	if stateTimestamp.IsZero() {
+		stateTimestamp = time.Now()
+	}
+
 	return &api.Cell{
 		DeployableEntity: api.DeployableEntity{
 			Entity: api.Entity{
@@ -219,7 +232,7 @@ func NewAPICell(input *NewCell) *api.Cell {
 				Version: 0,
 			},
 			State:          state,
-			StateTimestamp: input.StateTimestamp.UTC(), // Force UTC
+			StateTimestamp: stateTimestamp.UTC(), // Force UTC
 		},
 		ExternalID: input.ExternalID,
 		Properties: api.ToProperties(input.Properties),

--- a/tmanager/model/v1alpha1/transformers_test.go
+++ b/tmanager/model/v1alpha1/transformers_test.go
@@ -482,6 +482,48 @@ func TestEmptyAndNilInputs(t *testing.T) {
 	})
 }
 
+func TestNewAPICell_Defaults(t *testing.T) {
+	before := time.Now().UTC()
+
+	input := NewCell{
+		ExternalID: "ext-1",
+		Properties: map[string]any{"key": "value"},
+	}
+
+	result := NewAPICell(&input)
+
+	after := time.Now().UTC()
+
+	require.NotNil(t, result)
+	assert.NotEmpty(t, result.ID)
+	assert.Equal(t, int64(0), result.Version)
+	assert.Equal(t, api.DeploymentStateInitial, result.State)
+	assert.Equal(t, "ext-1", result.ExternalID)
+	assert.Contains(t, result.Properties, "key")
+
+	// StateTimestamp should default to approximately now
+	assert.False(t, result.StateTimestamp.IsZero(), "StateTimestamp should not be zero")
+	assert.True(t, !result.StateTimestamp.Before(before), "StateTimestamp should be >= test start time")
+	assert.True(t, !result.StateTimestamp.After(after), "StateTimestamp should be <= test end time")
+}
+
+func TestNewAPICell_ExplicitValues(t *testing.T) {
+	testTime := time.Date(2025, 8, 12, 20, 30, 45, 123000000, time.FixedZone("CET", 1*60*60))
+
+	input := NewCell{
+		State:          "active",
+		StateTimestamp: testTime,
+		ExternalID:     "ext-2",
+		Properties:     map[string]any{"key": "value"},
+	}
+
+	result := NewAPICell(&input)
+
+	require.NotNil(t, result)
+	assert.Equal(t, api.DeploymentStateActive, result.State)
+	assert.Equal(t, testTime.UTC(), result.StateTimestamp)
+}
+
 func TestToDataspaceProfile(t *testing.T) {
 	testTime := time.Date(2025, 1, 15, 10, 30, 45, 0, time.UTC)
 


### PR DESCRIPTION
## Summary
- `NewCell.State` defaults to `"initial"` when omitted
- `NewCell.StateTimestamp` defaults to `time.Now().UTC()` when omitted
- Removed `required:"true"` tags from server-generated fields (`Entity.ID`, `Entity.Version`) and from `DeployableEntity` state fields
- Added `omitempty` to `NewCell.State` and `NewCell.StateTimestamp` JSON tags

This makes the API easier to use by not requiring clients to provide values that the server can sensibly default.

Closes #17

## Test plan
- [x] `TestNewAPICell_Defaults` — verifies State defaults to `initial` and StateTimestamp defaults to now
- [x] `TestNewAPICell_ExplicitValues` — verifies explicit values are preserved
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)