### PR TITLE
feat: validate Activity.input mappings against ActivityDefinition.InputSchema

### DIFF
--- a/pmanager/core/definition_manager.go
+++ b/pmanager/core/definition_manager.go
@@ -36,12 +36,26 @@ func (d definitionManager) CreateOrchestrationDefinition(ctx context.Context, de
 
 		// Verify that all referenced activities exist
 		for _, activity := range definition.Activities {
-			exists, err := d.store.ExistsActivityDefinition(ctx, activity.Type)
+			activityDefinition, err := d.store.FindActivityDefinition(ctx, activity.Type)
 			if err != nil {
+				if errors.Is(err, types.ErrNotFound) {
+					missingErrors = append(missingErrors, types.NewClientError("activity type '%s' not found", activity.Type))
+					continue
+				}
 				return nil, err
 			}
-			if !exists {
-				missingErrors = append(missingErrors, types.NewClientError("activity type '%s' not found", activity.Type))
+			if len(activity.Inputs) == 0 {
+				continue
+			}
+			properties, ok := activityDefinition.InputSchema["properties"].(map[string]any)
+			if !ok {
+				continue
+			}
+
+			for _, input := range activity.Inputs {
+				if _, exists := properties[input.Target]; !exists {
+					missingErrors = append(missingErrors, types.NewClientError("activity input target '%s' is not defined in input schema '%s'", input.Target, activity.Type))
+				}
 			}
 		}
 

--- a/pmanager/core/definition_manager_test.go
+++ b/pmanager/core/definition_manager_test.go
@@ -881,6 +881,80 @@ func TestDeleteActivityDefinition_AfterOrchestrationDeletion(t *testing.T) {
 	assert.False(t, exists, "Activity definition should no longer exist")
 }
 
+func TestCreateOrchestrationDefinition_ActivityInputValidSchema(t *testing.T) {
+	store := memorystore.NewDefinitionStore()
+	manager := definitionManager{
+		trxContext: cstore.NoOpTransactionContext{},
+		store:      store,
+	}
+	ctx := context.Background()
+	activityDef := &api.ActivityDefinition{
+		Type: "input-schema-activity",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"field-one": map[string]any{"type": "string"},
+				"field-two": map[string]any{"type": "string"},
+			},
+		},
+	}
+	_, err := store.StoreActivityDefinition(ctx, activityDef)
+	require.NoError(t, err, "Failed to store activity definition")
+	orchestrationDef := &api.OrchestrationDefinition{
+		Type:   model.OrchestrationType("input-schema-orchestration"),
+		Active: true,
+		Activities: []api.Activity{
+			{
+				ID:   "activity-1",
+				Type: "input-schema-activity",
+				Inputs: []api.MappingEntry{
+					{Source: "field-1", Target: "field-one"},
+					{Source: "field-2", Target: "field-two"}},
+			},
+		},
+	}
+	result, err := manager.CreateOrchestrationDefinition(ctx, orchestrationDef)
+	require.NoError(t, err, "The creation of an orchestration should pass when the activity input fields map the schema")
+	assert.NotNil(t, result, "The result should not be nil")
+}
+
+func TestCreateOrchestrationDefinition_ActivityInputInvalidSchema(t *testing.T) {
+	store := memorystore.NewDefinitionStore()
+	manager := definitionManager{
+		trxContext: cstore.NoOpTransactionContext{},
+		store:      store,
+	}
+	ctx := context.Background()
+	activityDef := &api.ActivityDefinition{
+		Type: "input-schema-activity",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"field-one": map[string]any{"type": "string"},
+			},
+		},
+	}
+	_, err := store.StoreActivityDefinition(ctx, activityDef)
+	require.NoError(t, err, "Failed to store activity definition")
+	orchestrationDef := &api.OrchestrationDefinition{
+		Type:   model.OrchestrationType("input-schema-orchestration"),
+		Active: true,
+		Activities: []api.Activity{
+			{
+				ID:   "activity-1",
+				Type: "input-schema-activity",
+				Inputs: []api.MappingEntry{
+					{Source: "not-existing-field", Target: "not-existing-field"},
+				},
+			},
+		},
+	}
+	result, err := manager.CreateOrchestrationDefinition(ctx, orchestrationDef)
+	require.Error(t, err, "The creation of an orchestration should fail when the input field doesn't exists in the schema")
+	assert.Nil(t, result, "The result should be nil on error")
+	assert.Contains(t, err.Error(), "not-existing-field", "Error should mention invalid Activity Input")
+}
+
 // Helper mock store for testing error scenarios
 type mockDefinitionStore struct {
 	simulatedErrors map[string]error


### PR DESCRIPTION
This PR adds a validation  on the creation of an orchestration-definition to ensure that Activity.Inputs match the fields from the InputSchema of the ActivityDefinition. 

Closes: #81 