### PR TITLE
feat: extend ActivityProcessor interface

### DIFF
--- a/agent/edcv/activity/activity.go
+++ b/agent/edcv/activity/activity.go
@@ -28,6 +28,7 @@ import (
 )
 
 type EDCVActivityProcessor struct {
+	api.BaseActivityProcessor
 	VaultClient          serviceapi.VaultClient
 	HTTPClient           *http.Client
 	Monitor              system.LogMonitor
@@ -79,7 +80,7 @@ type Config struct {
 	ProtocolServiceURL   string
 }
 
-func (p EDCVActivityProcessor) Process(ctx api.ActivityContext) api.ActivityResult {
+func (p EDCVActivityProcessor) ProcessDeploy(ctx api.ActivityContext) api.ActivityResult {
 	var data EDCVData
 	err := ctx.ReadValues(&data)
 	if err != nil {
@@ -87,15 +88,16 @@ func (p EDCVActivityProcessor) Process(ctx api.ActivityContext) api.ActivityResu
 	}
 
 	participantContextId := data.ApiAccessClientID
+	return p.handleDeployAction(ctx, data, participantContextId)
+}
 
-	if ctx.Discriminator() == api.DeployDiscriminator {
-		return p.handleDeployAction(ctx, data, participantContextId)
-	} else if ctx.Discriminator() == api.DisposeDiscriminator {
-		return p.handleDisposeAction(participantContextId)
+func (p EDCVActivityProcessor) ProcessDispose(ctx api.ActivityContext) api.ActivityResult {
+	var data EDCVData
+	err := ctx.ReadValues(&data)
+	if err != nil {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing EDC-V activity for orchestration %s: %w", ctx.OID(), err)}
 	}
-
-	return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("the '%s' discriminator is not supported", ctx.Discriminator())}
-
+	return p.handleDisposeAction(data.ApiAccessClientID)
 }
 
 // handleDeployAction creates a participant context in IdentityHub and the control plane (incl. participant context config)

--- a/agent/edcv/activity/activity_test.go
+++ b/agent/edcv/activity/activity_test.go
@@ -82,7 +82,7 @@ func TestEDCVActivityProcessor_Process_WithValidData(t *testing.T) {
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)
 	assert.NoError(t, result.Error)
@@ -104,7 +104,7 @@ func TestEDCVActivityProcessor_Process_MissingParticipantID(t *testing.T) {
 
 	activityContext := api.NewActivityContext(ctx, "orchestration-1", activity, pd, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	require.NotNil(t, result)
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
@@ -127,7 +127,7 @@ func TestEDCVActivityProcessor_Process_MissingClientID(t *testing.T) {
 
 	activityContext := api.NewActivityContext(ctx, "orchestration-2", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	require.NotNil(t, result)
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
@@ -150,7 +150,7 @@ func TestEDCVActivityProcessor_Process_MissingCredentialServiceUrl(t *testing.T)
 
 	activityContext := api.NewActivityContext(ctx, "orchestration-2", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	require.NotNil(t, result)
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
@@ -173,7 +173,7 @@ func TestEDCVActivityProcessor_Process_MissingProtocolServiceUrl(t *testing.T) {
 
 	activityContext := api.NewActivityContext(ctx, "orchestration-2", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	require.NotNil(t, result)
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
@@ -194,7 +194,7 @@ func TestEDCVActivityProcessor_Process_EmptyProcessingData(t *testing.T) {
 
 	activityContext := api.NewActivityContext(ctx, "orchestration-3", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	require.NotNil(t, result)
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
@@ -216,7 +216,7 @@ func TestEDCVActivityProcessor_Process_InvalidDataTypes(t *testing.T) {
 
 	activityContext := api.NewActivityContext(ctx, "orchestration-4", activity, pd, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	require.NotNil(t, result)
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
@@ -244,7 +244,7 @@ func TestEDCVActivityProcessor_Process_OrchestrationIDInError(t *testing.T) {
 	orchestrationID := "test-orch-12345"
 	activityContext := api.NewActivityContext(ctx, orchestrationID, activity, pd, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	require.NotNil(t, result)
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
@@ -272,7 +272,7 @@ func TestEDCVActivityProcessor_Process_MultipleUnknownFields(t *testing.T) {
 
 	activityContext := api.NewActivityContext(ctx, "orch-multi", activity, pd, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	require.NotNil(t, result)
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)
@@ -298,7 +298,7 @@ func TestEDCVActivityProcessor_Process_MissingVaultEntry(t *testing.T) {
 
 	activityContext := api.NewActivityContext(ctx, "orch-multi", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	assert.NotNil(t, result.Error)
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
@@ -318,7 +318,7 @@ func TestEDCVActivityProcessor_Process_IdentityHubFailure(t *testing.T) {
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
 	assert.Error(t, result.Error, "some error")
@@ -338,7 +338,7 @@ func TestEDCVActivityProcessor_Process_ManagementAPIFailure(t *testing.T) {
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
 	assert.ErrorContains(t, result.Error, "some error")
@@ -358,7 +358,7 @@ func TestEDCVActivityProcessor_Process_ManagementAPIFailureConfig(t *testing.T) 
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
 	assert.ErrorContains(t, result.Error, "some error")
@@ -379,7 +379,7 @@ func TestEDCVActivityProcessor_ProcessDispose(t *testing.T) {
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDispose(activityContext)
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)
 	assert.NoError(t, result.Error)
@@ -402,7 +402,7 @@ func TestEDCVActivityProcessor_ProcessDispose_CtrlPlaneParticipantError(t *testi
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDispose(activityContext)
 
 	// expect to complete successfully, to unblock subsequent agents
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)
@@ -425,7 +425,7 @@ func TestEDCVActivityProcessor_ProcessDispose_CtrlPlaneConfigError(t *testing.T)
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDispose(activityContext)
 
 	// expect to complete successfully, to unblock subsequent agents
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)
@@ -448,7 +448,7 @@ func TestEDCVActivityProcessor_ProcessDispose_IdentityHubError(t *testing.T) {
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDispose(activityContext)
 
 	// expect to complete successfully, to unblock subsequent agents
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)

--- a/agent/keycloak/activity/activity.go
+++ b/agent/keycloak/activity/activity.go
@@ -52,6 +52,7 @@ type Config struct {
 // KeyCloakActivityProcessor creates a confidential client in Keycloak and stores the client secret in Vault for use by
 // other processors. The client ID is returned as a value in the context.
 type KeyCloakActivityProcessor struct {
+	api.BaseActivityProcessor
 	keycloakURL string
 	clientId    string
 	username    string
@@ -198,19 +199,7 @@ func NewProcessor(config *Config) *KeyCloakActivityProcessor {
 	}
 }
 
-func (p KeyCloakActivityProcessor) Process(ctx api.ActivityContext) api.ActivityResult {
-	if ctx.Discriminator() == api.DeployDiscriminator {
-		return p.handleDeployAction(ctx)
-	}
-
-	if ctx.Discriminator() == api.DisposeDiscriminator {
-		return p.handleDisposeAction(ctx)
-	}
-	return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("the '%s' discriminator is not supported", ctx.Discriminator())}
-}
-
-// handleDeployAction handles the deployment process, creating required Keycloak clients for API and Vault access.
-func (p KeyCloakActivityProcessor) handleDeployAction(ctx api.ActivityContext) api.ActivityResult {
+func (p KeyCloakActivityProcessor) ProcessDeploy(ctx api.ActivityContext) api.ActivityResult {
 	clientIDSlug := generateClientID()
 
 	// create Keycloak client for API access
@@ -245,8 +234,7 @@ func (p KeyCloakActivityProcessor) handleDeployAction(ctx api.ActivityContext) a
 	return vaultClientResult
 }
 
-// handleDisposeAction handles the disposal of Keycloak clients, removing API and Vault access clients if they exist.
-func (p KeyCloakActivityProcessor) handleDisposeAction(ctx api.ActivityContext) api.ActivityResult {
+func (p KeyCloakActivityProcessor) ProcessDispose(ctx api.ActivityContext) api.ActivityResult {
 	apiAccessID := ctx.Values()[apiAccessClientIDKey].(string)
 	vaultAccessID := ctx.Values()[vaultAccessClientIDKey].(string)
 	if vaultAccessID != "" && apiAccessID != "" {

--- a/agent/onboarding/activity/activity.go
+++ b/agent/onboarding/activity/activity.go
@@ -25,6 +25,7 @@ import (
 )
 
 type OnboardingActivityProcessor struct {
+	api.BaseActivityProcessor
 	Monitor                system.LogMonitor
 	IdentityApiClient      identityhub.IdentityAPIClient
 	IssuerServiceApiClient issuerservice.ApiClient
@@ -37,16 +38,71 @@ type credentialRequestData struct {
 	CredentialRequestURL string `json:"credentialRequest"`
 }
 
-func (p OnboardingActivityProcessor) Process(ctx api.ActivityContext) api.ActivityResult {
-
-	if ctx.Discriminator() == api.DeployDiscriminator {
-		return p.handleDeployAction(ctx)
+// handleDeployAction processes the deploy action for an onboarding activity by requesting the issuance of verifiable credentials.
+// if a credential request is in progress, the deploy action simply checks its status and reschedules itself.
+func (p OnboardingActivityProcessor) ProcessDeploy(ctx api.ActivityContext) api.ActivityResult {
+	var credentialRequest credentialRequestData
+	if err := ctx.ReadValues(&credentialRequest); err != nil {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing Onboarding activity for orchestration %s: %w", ctx.OID(), err)}
 	}
-	if ctx.Discriminator() == api.DisposeDiscriminator {
-		return p.handleDisposeAction(ctx)
+
+	// no credential request was made yet -> make one
+	if "" == credentialRequest.HolderPID {
+		var data onboardingData
+		if err := ctx.ReadValues(&data); err != nil {
+			return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing Onboarding activity for orchestration %s: %w", ctx.OID(), err)}
+		}
+		return p.processNewRequest(ctx, &data, credentialRequest)
+	}
+	// holderPID exists, check the status of the issuance
+	return p.processExistingRequest(ctx, credentialRequest)
+}
+
+// handleDisposeAction revokes a credential using the IssuerService's Admin API. The credential is NOT deleted from the
+// holder wallet (IdentityHub).
+func (p OnboardingActivityProcessor) ProcessDispose(ctx api.ActivityContext) api.ActivityResult {
+
+	var credentialRequest credentialRequestData
+	if err := ctx.ReadValues(&credentialRequest); err != nil {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing Onboarding activity for orchestration %s: %w", ctx.OID(), err)}
 	}
 
-	return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("the '%s' discriminator is not supported", ctx.Discriminator())}
+	var data onboardingData
+	if err := ctx.ReadValues(&data); err != nil {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing Onboarding activity for orchestration %s: %w", ctx.OID(), err)}
+	}
+
+	participantContextID := credentialRequest.ParticipantContextID
+	// query credentials by type, using the IdentityAPI
+	var revocationErrors []error
+
+	for _, spec := range data.CredentialSpecs {
+		credentialType := spec.Type
+
+		credentials, err := p.IdentityApiClient.QueryCredentialByType(participantContextID, credentialType)
+		if err != nil {
+			return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error querying credentials by type %s for participant context %s: %w", credentialType, participantContextID, err)}
+		}
+
+		if len(credentials) == 0 {
+			p.Monitor.Infof("Rollback: could not revoke credentials of type '%s': 0 found for participant context '%s'", credentialType, participantContextID)
+			return api.ActivityResult{Result: api.ActivityResultComplete}
+		}
+
+		// for each credential, send a revocation request
+		for _, credential := range credentials {
+			err := p.IssuerServiceApiClient.RevokeCredential(participantContextID, credential.VerifiableCredential.Credential.ID)
+			if err != nil {
+				revocationErrors = append(revocationErrors, err)
+			}
+		}
+	}
+
+	if len(revocationErrors) > 0 {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error revoking one or more credentials: %v", revocationErrors)}
+	}
+
+	return api.ActivityResult{Result: api.ActivityResultComplete}
 }
 
 func (p OnboardingActivityProcessor) processExistingRequest(ctx api.ActivityContext, credentialRequest credentialRequestData) api.ActivityResult {
@@ -121,73 +177,6 @@ func (p OnboardingActivityProcessor) processNewRequest(ctx api.ActivityContext, 
 		WaitOnReschedule: time.Duration(5) * time.Second,
 		Error:            nil,
 	}
-}
-
-// handleDeployAction processes the deploy action for an onboarding activity by requesting the issuance of verifiable credentials.
-// if a credential request is in progress, the deploy action simply checks its status and reschedules itself.
-func (p OnboardingActivityProcessor) handleDeployAction(ctx api.ActivityContext) api.ActivityResult {
-	var credentialRequest credentialRequestData
-	if err := ctx.ReadValues(&credentialRequest); err != nil {
-		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing Onboarding activity for orchestration %s: %w", ctx.OID(), err)}
-	}
-
-	// no credential request was made yet -> make one
-	if "" == credentialRequest.HolderPID {
-		var data onboardingData
-		if err := ctx.ReadValues(&data); err != nil {
-			return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing Onboarding activity for orchestration %s: %w", ctx.OID(), err)}
-		}
-		return p.processNewRequest(ctx, &data, credentialRequest)
-	}
-	// holderPID exists, check the status of the issuance
-	return p.processExistingRequest(ctx, credentialRequest)
-}
-
-// handleDisposeAction revokes a credential using the IssuerService's Admin API. The credential is NOT deleted from the
-// holder wallet (IdentityHub).
-func (p OnboardingActivityProcessor) handleDisposeAction(ctx api.ActivityContext) api.ActivityResult {
-
-	var credentialRequest credentialRequestData
-	if err := ctx.ReadValues(&credentialRequest); err != nil {
-		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing Onboarding activity for orchestration %s: %w", ctx.OID(), err)}
-	}
-
-	var data onboardingData
-	if err := ctx.ReadValues(&data); err != nil {
-		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing Onboarding activity for orchestration %s: %w", ctx.OID(), err)}
-	}
-
-	participantContextID := credentialRequest.ParticipantContextID
-	// query credentials by type, using the IdentityAPI
-	var revocationErrors []error
-
-	for _, spec := range data.CredentialSpecs {
-		credentialType := spec.Type
-
-		credentials, err := p.IdentityApiClient.QueryCredentialByType(participantContextID, credentialType)
-		if err != nil {
-			return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error querying credentials by type %s for participant context %s: %w", credentialType, participantContextID, err)}
-		}
-
-		if len(credentials) == 0 {
-			p.Monitor.Infof("Rollback: could not revoke credentials of type '%s': 0 found for participant context '%s'", credentialType, participantContextID)
-			return api.ActivityResult{Result: api.ActivityResultComplete}
-		}
-
-		// for each credential, send a revocation request
-		for _, credential := range credentials {
-			err := p.IssuerServiceApiClient.RevokeCredential(participantContextID, credential.VerifiableCredential.Credential.ID)
-			if err != nil {
-				revocationErrors = append(revocationErrors, err)
-			}
-		}
-	}
-
-	if len(revocationErrors) > 0 {
-		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error revoking one or more credentials: %v", revocationErrors)}
-	}
-
-	return api.ActivityResult{Result: api.ActivityResultComplete}
 }
 
 type onboardingData struct {

--- a/agent/onboarding/activity/activity_test.go
+++ b/agent/onboarding/activity/activity_test.go
@@ -55,7 +55,7 @@ func TestOnboardingActivityProcessor_ProcessDeploy_WhenNewRequest(t *testing.T) 
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultSchedule), result.Result)
 	assert.NoError(t, result.Error)
@@ -97,7 +97,7 @@ func TestOnboardingActivityProcessor_ProcessDeploy_WhenNewRequestError(t *testin
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
 	assert.ErrorContains(t, result.Error, "some error")
@@ -131,7 +131,7 @@ func TestOnboardingActivityProcessor_ProcessDeploy_WhenPendingRequestApiError(t 
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
 	assert.ErrorContains(t, result.Error, "some error")
@@ -165,7 +165,7 @@ func TestOnboardingActivityProcessor_ProcessDeploy_WhenPendingRequestIssued(t *t
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)
 	assert.NoError(t, result.Error)
@@ -202,7 +202,7 @@ func TestOnboardingActivityProcessor_ProcessDeploy_WhenPendingRequestCreated(t *
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultSchedule), result.Result)
 	assert.NoError(t, result.Error)
@@ -237,7 +237,7 @@ func TestOnboardingActivityProcessor_ProcessDeploy_WhenPendingRequestRejected(t 
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
 	assert.ErrorContains(t, result.Error, "credential request for participant 'test-participant' was rejected")
@@ -272,7 +272,7 @@ func TestOnboardingActivityProcessor_ProcessDeploy_WhenPendingRequestError(t *te
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
 	assert.ErrorContains(t, result.Error, "credential request for participant 'test-participant' failed")
@@ -300,7 +300,7 @@ func TestOnboardingActivityProcessor_ProcessDeploy_WhenInvalidData(t *testing.T)
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
 	assert.Error(t, result.Error)
@@ -333,7 +333,7 @@ func TestOnboardingActivityProcessor_ProcessDeploy_WhenInvalidStateReceived(t *t
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultRetryError), result.Result)
 	assert.ErrorContains(t, result.Error, "unexpected credential request state ")
@@ -384,11 +384,12 @@ func TestOnboardingActivityProcessor_ProcessDispose(t *testing.T) {
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDispose(activityContext)
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)
 	assert.NoError(t, result.Error)
 }
+
 func TestOnboardingActivityProcessor_ProcessDispose_RevocationFails(t *testing.T) {
 	ih := MockIdentityHubClient{
 		expectedCredentials: []identityhub.VerifiableCredentialResource{
@@ -433,7 +434,7 @@ func TestOnboardingActivityProcessor_ProcessDispose_RevocationFails(t *testing.T
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDispose(activityContext)
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
 	assert.ErrorContains(t, result.Error, "some error")
@@ -474,7 +475,7 @@ func TestOnboardingActivityProcessor_ProcessDispose_NoCredentials(t *testing.T) 
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDispose(activityContext)
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)
 	assert.NoError(t, result.Error)

--- a/agent/registration/activity/activity.go
+++ b/agent/registration/activity/activity.go
@@ -21,6 +21,7 @@ import (
 )
 
 type RegistrationActivityProcessor struct {
+	api.BaseActivityProcessor
 	Monitor       system.LogMonitor
 	IssuerService issuerservice.ApiClient
 }
@@ -42,22 +43,11 @@ type Config struct {
 	IssuerService issuerservice.ApiClient
 }
 
-func (p RegistrationActivityProcessor) Process(ctx api.ActivityContext) api.ActivityResult {
+func (p RegistrationActivityProcessor) ProcessDeploy(ctx api.ActivityContext) api.ActivityResult {
 	var registrationData RegistrationData
 	if err := ctx.ReadValues(&registrationData); err != nil {
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing Registration activity for orchestration %s: %w", ctx.OID(), err)}
 	}
-
-	if ctx.Discriminator() == api.DeployDiscriminator {
-		return p.handleDeployAction(registrationData)
-	} else if ctx.Discriminator() == api.DisposeDiscriminator {
-		return p.handleDisposeAction(registrationData)
-	}
-	return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("the '%s' discriminator is not supported", ctx.Discriminator())}
-
-}
-
-func (p RegistrationActivityProcessor) handleDeployAction(registrationData RegistrationData) api.ActivityResult {
 	if registrationData.HolderName == "" {
 		registrationData.HolderName = registrationData.DID
 	}
@@ -71,13 +61,16 @@ func (p RegistrationActivityProcessor) handleDeployAction(registrationData Regis
 	return api.ActivityResult{Result: api.ActivityResultComplete}
 }
 
-func (p RegistrationActivityProcessor) handleDisposeAction(data RegistrationData) api.ActivityResult {
-
-	holderID := data.DID
+func (p RegistrationActivityProcessor) ProcessDispose(ctx api.ActivityContext) api.ActivityResult {
+	var registrationData RegistrationData
+	if err := ctx.ReadValues(&registrationData); err != nil {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing Registration activity for orchestration %s: %w", ctx.OID(), err)}
+	}
+	holderID := registrationData.DID
 	if err := p.IssuerService.DeleteHolder(holderID); err != nil {
 		// todo: inspect error if it is retryable
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("registration rollback: error deleting holder in IssuerService: %w", err)}
 	}
-	p.Monitor.Debugf("Registration rollback: activity for participant '%s' completed successfully", data.DID)
+	p.Monitor.Debugf("Registration rollback: activity for participant '%s' completed successfully", registrationData.DID)
 	return api.ActivityResult{Result: api.ActivityResultComplete}
 }

--- a/agent/registration/activity/activity_test.go
+++ b/agent/registration/activity/activity_test.go
@@ -45,7 +45,7 @@ func TestRegistrationActivityProcessor_MinimalValidData(t *testing.T) {
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)
 	assert.NoError(t, result.Error)
@@ -76,7 +76,7 @@ func TestRegistrationActivityProcessor_FullValidData(t *testing.T) {
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)
 	assert.NoError(t, result.Error)
@@ -104,7 +104,7 @@ func TestRegistrationActivityProcessor_InvalidData(t *testing.T) {
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
 	assert.Error(t, result.Error)
@@ -132,13 +132,13 @@ func TestRegistrationActivityProcessor_IssuerServiceFails(t *testing.T) {
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDeploy(activityContext)
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
 	assert.ErrorContains(t, result.Error, "some error")
 }
 
-func TestRegistrationActivityProcessor_Rollback(t *testing.T) {
+func TestRegistrationActivityProcessor_ProcessDispose(t *testing.T) {
 	issuerService := MockIssuerService{}
 	processor := NewProcessor(&Config{
 		LogMonitor:    system.NoopMonitor{},
@@ -160,13 +160,13 @@ func TestRegistrationActivityProcessor_Rollback(t *testing.T) {
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDispose(activityContext)
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)
 	assert.NoError(t, result.Error)
 }
 
-func TestRegistrationActivityProcessor_Rollback_IssuerServiceFails(t *testing.T) {
+func TestRegistrationActivityProcessor_ProcessDispose_IssuerServiceFails(t *testing.T) {
 	issuerService := MockIssuerService{expectedError: fmt.Errorf("some error")}
 	processor := NewProcessor(&Config{
 		LogMonitor:    system.NoopMonitor{},
@@ -188,7 +188,7 @@ func TestRegistrationActivityProcessor_Rollback_IssuerServiceFails(t *testing.T)
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
 
-	result := processor.Process(activityContext)
+	result := processor.ProcessDispose(activityContext)
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
 	assert.ErrorContains(t, result.Error, "some error")

--- a/e2e/testagent/launcher/launcher.go
+++ b/e2e/testagent/launcher/launcher.go
@@ -59,6 +59,14 @@ type TestActivityProcessor struct {
 	callback func(ctx api.ActivityContext) api.ActivityResult
 }
 
+func (t TestActivityProcessor) ProcessDeploy(activityContext api.ActivityContext) api.ActivityResult {
+	return t.Process(activityContext)
+}
+
+func (t TestActivityProcessor) ProcessDispose(activityContext api.ActivityContext) api.ActivityResult {
+	return t.Process(activityContext)
+}
+
 func (t TestActivityProcessor) Process(ctx api.ActivityContext) api.ActivityResult {
 	if t.callback != nil {
 		return t.callback(ctx)

--- a/pmanager/api/provision.go
+++ b/pmanager/api/provision.go
@@ -17,6 +17,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"iter"
 	"reflect"
 
@@ -70,18 +71,22 @@ type Orchestrator interface {
 	GetOrchestration(ctx context.Context, id string) (*Orchestration, error)
 }
 
-// ActivityProcessor executes activities for a given type.
-//
-// If the execution completes successfully, the processor returns ActivityResultComplete.
-//
-// If the processor returns ActivityResultWait, the activity will remain outstanding until completion is asynchronously signaled.
-//
-// If the processor returns ActivityResultSchedule, the orchestration engine will reschedule message delivery in the duration
-// defined by WaitOnReschedule.
-//
-// If the processor encounters an error, it returns an ActivityResultRetryError or an ActivityResultFatalError.
+// ActivityProcessor defines an interface for processing various activities within an orchestrated workflow.
+// Process handles a generic activity, taking an ActivityContext and returning an ActivityResult.
+// ProcessDeploy handles deployment-specific activities, taking an ActivityContext and returning an ActivityResult.
+// ProcessDispose handles disposal-specific activities, taking an ActivityContext and returning an ActivityResult.
 type ActivityProcessor interface {
 	Process(activityContext ActivityContext) ActivityResult
+	ProcessDeploy(activityContext ActivityContext) ActivityResult
+	ProcessDispose(activityContext ActivityContext) ActivityResult
+}
+
+// BaseActivityProcessor provides default implementations for processing activity lifecycle methods in an orchestration system.
+type BaseActivityProcessor struct {
+}
+
+func (p BaseActivityProcessor) Process(ctx ActivityContext) ActivityResult {
+	return ActivityResult{Result: ActivityResultFatalError, Error: fmt.Errorf("the '%s' discriminator is not supported", ctx.Discriminator())}
 }
 
 type ActivityResultType int

--- a/pmanager/natsagent/launcher_test.go
+++ b/pmanager/natsagent/launcher_test.go
@@ -180,7 +180,16 @@ func (m *MockServiceAssembly) Shutdown() error {
 }
 
 // MockActivityProcessor implements api.ActivityProcessor for testing
-type MockActivityProcessor struct{}
+type MockActivityProcessor struct {
+}
+
+func (m *MockActivityProcessor) ProcessDispose(activityContext api.ActivityContext) api.ActivityResult {
+	return api.ActivityResult{Result: api.ActivityResultComplete}
+}
+
+func (m *MockActivityProcessor) ProcessDeploy(activityContext api.ActivityContext) api.ActivityResult {
+	return api.ActivityResult{Result: api.ActivityResultComplete}
+}
 
 func (m *MockActivityProcessor) Process(activityContext api.ActivityContext) api.ActivityResult {
 	return api.ActivityResult{Result: api.ActivityResultComplete}

--- a/pmanager/natsorchestration/activity.go
+++ b/pmanager/natsorchestration/activity.go
@@ -108,7 +108,14 @@ func (e *NatsActivityExecutor) processMessage(ctx context.Context, message jetst
 		orchestration.OutputData)
 
 	e.Monitor.Debugf("Received activity message %s for orchestration %s", oMessage.Activity.ID, oMessage.OrchestrationID)
-	result := e.ActivityProcessor.Process(activityContext)
+	var result api.ActivityResult
+	if activityContext.Discriminator() == api.DeployDiscriminator {
+		result = e.ActivityProcessor.ProcessDeploy(activityContext)
+	} else if activityContext.Discriminator() == api.DisposeDiscriminator {
+		result = e.ActivityProcessor.ProcessDispose(activityContext)
+	} else {
+		result = e.ActivityProcessor.Process(activityContext)
+	}
 
 	switch result.Result {
 	case api.ActivityResultRetryError:

--- a/pmanager/natsorchestration/activity_completion_test.go
+++ b/pmanager/natsorchestration/activity_completion_test.go
@@ -338,7 +338,9 @@ func TestNatsActivityExecutor_RescheduleWithCounter(t *testing.T) {
 }
 
 // TestCompleteActivityProcessor always returns complete
-type TestCompleteActivityProcessor struct{}
+type TestCompleteActivityProcessor struct {
+	DefaultTestProcessor
+}
 
 func (p *TestCompleteActivityProcessor) Process(ctx api.ActivityContext) api.ActivityResult {
 	return api.ActivityResult{
@@ -347,7 +349,9 @@ func (p *TestCompleteActivityProcessor) Process(ctx api.ActivityContext) api.Act
 }
 
 // TestFatalErrorActivityProcessor always returns fatal error
-type TestFatalErrorActivityProcessor struct{}
+type TestFatalErrorActivityProcessor struct {
+	DefaultTestProcessor
+}
 
 func (p *TestFatalErrorActivityProcessor) Process(ctx api.ActivityContext) api.ActivityResult {
 	return api.ActivityResult{
@@ -358,6 +362,7 @@ func (p *TestFatalErrorActivityProcessor) Process(ctx api.ActivityContext) api.A
 
 // TestRescheduleCounterActivityProcessor reschedules once using a counter, then completes
 type TestRescheduleCounterActivityProcessor struct {
+	DefaultTestProcessor
 	CallCount int
 }
 

--- a/pmanager/natsorchestration/activity_persistence_test.go
+++ b/pmanager/natsorchestration/activity_persistence_test.go
@@ -154,6 +154,7 @@ func TestNatsActivityExecutor_ProcessingDataPersistedAcrossReschedules(t *testin
 // TestPersistenceActivityProcessor reschedules multiple times using a counter,
 // testing that the counter value persists across reschedule boundaries
 type TestPersistenceActivityProcessor struct {
+	DefaultTestProcessor
 	CallCount       int
 	RescheduleCount int
 	CompleteCount   int

--- a/pmanager/natsorchestration/orchestration_parallel_test.go
+++ b/pmanager/natsorchestration/orchestration_parallel_test.go
@@ -143,6 +143,7 @@ outerLoop:
 
 // FailingActivityProcessor wraps a TestActivityProcessor and always returns an error
 type FailingActivityProcessor struct {
+	DefaultTestProcessor
 	testProcessor TestActivityProcessor
 }
 

--- a/pmanager/natsorchestration/orchestration_persistence_test.go
+++ b/pmanager/natsorchestration/orchestration_persistence_test.go
@@ -596,6 +596,7 @@ func Test_ValuePersistenceOnWait(t *testing.T) {
 // Generic test processors
 
 type GenericValueProcessor struct {
+	DefaultTestProcessor
 	onProcess func(api.ActivityContext)
 }
 
@@ -607,6 +608,7 @@ func (p *GenericValueProcessor) Process(ctx api.ActivityContext) api.ActivityRes
 }
 
 type GenericRetryProcessor struct {
+	DefaultTestProcessor
 	onProcess func(api.ActivityContext) api.ActivityResult
 }
 
@@ -618,6 +620,7 @@ func (p *GenericRetryProcessor) Process(ctx api.ActivityContext) api.ActivityRes
 }
 
 type GenericWaitProcessor struct {
+	DefaultTestProcessor
 	onProcess func(api.ActivityContext)
 }
 
@@ -631,6 +634,7 @@ func (p *GenericWaitProcessor) Process(ctx api.ActivityContext) api.ActivityResu
 // Test processors
 
 type ValueSettingProcessor struct {
+	DefaultTestProcessor
 	onProcess func(api.ActivityContext)
 }
 
@@ -642,6 +646,7 @@ func (p *ValueSettingProcessor) Process(ctx api.ActivityContext) api.ActivityRes
 }
 
 type RetryWithValueProcessor struct {
+	DefaultTestProcessor
 	onProcess func(api.ActivityContext) api.ActivityResult
 }
 
@@ -653,6 +658,7 @@ func (p *RetryWithValueProcessor) Process(ctx api.ActivityContext) api.ActivityR
 }
 
 type MultiActivityValueProcessor struct {
+	DefaultTestProcessor
 	onProcess func(api.ActivityContext)
 }
 
@@ -664,6 +670,7 @@ func (p *MultiActivityValueProcessor) Process(ctx api.ActivityContext) api.Activ
 }
 
 type WaitWithValueProcessor struct {
+	DefaultTestProcessor
 	onProcess func(api.ActivityContext)
 }
 

--- a/pmanager/natsorchestration/orchestration_test.go
+++ b/pmanager/natsorchestration/orchestration_test.go
@@ -342,6 +342,7 @@ func TestActivityProcessor_ScheduleThenContinue(t *testing.T) {
 // ScheduleThenContinueProcessor implements ActivityProcessor
 // Returns ActivityResultSchedule on first call, ActivityResultComplete on subsequent calls
 type ScheduleThenContinueProcessor struct {
+	DefaultTestProcessor
 	callCount int
 	wg        *sync.WaitGroup
 }
@@ -369,6 +370,7 @@ func (p *ScheduleThenContinueProcessor) Process(_ api.ActivityContext) api.Activ
 
 // TestActivityProcessor with timing information
 type TestActivityProcessor struct {
+	DefaultTestProcessor
 	onProcess func(id string)
 }
 

--- a/pmanager/natsorchestration/test_fixtures.go
+++ b/pmanager/natsorchestration/test_fixtures.go
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package natsorchestration
+
+import "github.com/eclipse-cfm/cfm/pmanager/api"
+
+type DefaultTestProcessor struct {
+}
+
+func (d DefaultTestProcessor) ProcessDeploy(activityContext api.ActivityContext) api.ActivityResult {
+	return api.ActivityResult{Result: api.ActivityResultComplete}
+}
+
+func (d DefaultTestProcessor) ProcessDispose(activityContext api.ActivityContext) api.ActivityResult {
+	return api.ActivityResult{Result: api.ActivityResultComplete}
+}
+
+func (d DefaultTestProcessor) Process(activityContext api.ActivityContext) api.ActivityResult {
+	return api.ActivityResult{Result: api.ActivityResultComplete}
+}


### PR DESCRIPTION
This PR moves the deploy/dispose logic into the `ActivityExecutor`, to avoid code duplication.

To do this, a base class `BaseActivityProcessor` was implemented, that all other activity processors embed to have a default behaviour.
All ActivityProcessor implementations are expected to provide `deploy` and `dispose` actions.


