### PR TITLE
feat: validate dependent activity input/output schema compatibility in orchestration definition

### DIFF
--- a/agent/keycloak/e2e/e2e_test.go
+++ b/agent/keycloak/e2e/e2e_test.go
@@ -194,7 +194,6 @@ func publishActivityMessage(ctx context.Context, id string, d api.Discriminator,
 			ID:            "test-activity",
 			Type:          launcher.ActivityType,
 			Discriminator: d,
-			Inputs:        make([]api.MappingEntry, 0),
 			DependsOn:     make([]string, 0),
 		},
 	}

--- a/pmanager/api/types.go
+++ b/pmanager/api/types.go
@@ -133,11 +133,10 @@ func (at ActivityType) String() string {
 }
 
 type Activity struct {
-	ID            string         `json:"id"`
-	Type          ActivityType   `json:"type"`
-	Discriminator Discriminator  `json:"discriminator"`
-	Inputs        []MappingEntry `json:"inputs"`
-	DependsOn     []string       `json:"dependsOn"`
+	ID            string        `json:"id"`
+	Type          ActivityType  `json:"type"`
+	Discriminator Discriminator `json:"discriminator"`
+	DependsOn     []string      `json:"dependsOn"`
 }
 
 // ActivityMessage used to enqueue an activity for processing.

--- a/pmanager/api/types_instantiate_test.go
+++ b/pmanager/api/types_instantiate_test.go
@@ -27,13 +27,11 @@ func TestInstantiateOrchestration(t *testing.T) {
 			{
 				ID:        "activity1",
 				Type:      "test-type",
-				Inputs:    []MappingEntry{{Source: "input1", Target: "target1"}},
 				DependsOn: []string{},
 			},
 			{
 				ID:        "activity2",
 				Type:      "test-type-2",
-				Inputs:    []MappingEntry{{Source: "input2", Target: "target2"}},
 				DependsOn: []string{},
 			},
 		}
@@ -71,19 +69,16 @@ func TestInstantiateOrchestration(t *testing.T) {
 			{
 				ID:        "activity1",
 				Type:      "first",
-				Inputs:    []MappingEntry{{Source: "input1", Target: "target1"}},
 				DependsOn: []string{},
 			},
 			{
 				ID:        "activity2",
 				Type:      "second",
-				Inputs:    []MappingEntry{{Source: "input2", Target: "target2"}},
 				DependsOn: []string{"activity1"},
 			},
 			{
 				ID:        "activity3",
 				Type:      "third",
-				Inputs:    []MappingEntry{{Source: "input3", Target: "target3"}},
 				DependsOn: []string{"activity2"},
 			},
 		}
@@ -120,25 +115,21 @@ func TestInstantiateOrchestration(t *testing.T) {
 			{
 				ID:        "activity1",
 				Type:      "root",
-				Inputs:    []MappingEntry{{Source: "input1", Target: "target1"}},
 				DependsOn: []string{},
 			},
 			{
 				ID:        "activity2",
 				Type:      "parallel1",
-				Inputs:    []MappingEntry{{Source: "input2", Target: "target2"}},
 				DependsOn: []string{"activity1"},
 			},
 			{
 				ID:        "activity3",
 				Type:      "parallel2",
-				Inputs:    []MappingEntry{{Source: "input3", Target: "target3"}},
 				DependsOn: []string{"activity1"},
 			},
 			{
 				ID:        "activity4",
 				Type:      "final",
-				Inputs:    []MappingEntry{{Source: "input4", Target: "target4"}},
 				DependsOn: []string{"activity2", "activity3"},
 			},
 		}
@@ -179,13 +170,11 @@ func TestInstantiateOrchestration(t *testing.T) {
 			{
 				ID:        "activity1",
 				Type:      "first",
-				Inputs:    []MappingEntry{{Source: "input1", Target: "target1"}},
 				DependsOn: []string{"activity2"},
 			},
 			{
 				ID:        "activity2",
 				Type:      "second",
-				Inputs:    []MappingEntry{{Source: "input2", Target: "target2"}},
 				DependsOn: []string{"activity1"},
 			},
 		}
@@ -218,7 +207,6 @@ func TestInstantiateOrchestration(t *testing.T) {
 			{
 				ID:        "activity1",
 				Type:      "test",
-				Inputs:    []MappingEntry{{Source: "input1", Target: "target1"}},
 				DependsOn: []string{},
 			},
 		}
@@ -243,31 +231,26 @@ func TestInstantiateOrchestration(t *testing.T) {
 			{
 				ID:        "activity1",
 				Type:      "init",
-				Inputs:    []MappingEntry{{Source: "input1", Target: "target1"}},
 				DependsOn: []string{},
 			},
 			{
 				ID:        "activity2",
 				Type:      "setup",
-				Inputs:    []MappingEntry{{Source: "input2", Target: "target2"}},
 				DependsOn: []string{},
 			},
 			{
 				ID:        "activity3",
 				Type:      "process",
-				Inputs:    []MappingEntry{{Source: "input3", Target: "target3"}},
 				DependsOn: []string{"activity1", "activity2"},
 			},
 			{
 				ID:        "activity4",
 				Type:      "validate",
-				Inputs:    []MappingEntry{{Source: "input4", Target: "target4"}},
 				DependsOn: []string{"activity3"},
 			},
 			{
 				ID:        "activity5",
 				Type:      "cleanup",
-				Inputs:    []MappingEntry{{Source: "input5", Target: "target5"}},
 				DependsOn: []string{"activity4"},
 			},
 		}
@@ -329,7 +312,6 @@ func TestInstantiateOrchestration(t *testing.T) {
 			{
 				ID:        "activity1",
 				Type:      "test",
-				Inputs:    []MappingEntry{{Source: "input1", Target: "target1"}},
 				DependsOn: []string{},
 			},
 		}
@@ -348,7 +330,6 @@ func TestInstantiateOrchestration(t *testing.T) {
 			{
 				ID:        "activity1",
 				Type:      "test",
-				Inputs:    []MappingEntry{{Source: "input1", Target: "target1"}},
 				DependsOn: []string{"non-existent-activity"},
 			},
 		}

--- a/pmanager/api/types_test.go
+++ b/pmanager/api/types_test.go
@@ -603,12 +603,8 @@ func TestGetNextActivities(t *testing.T) {
 				{
 					Activities: []Activity{
 						{
-							ID:   "complex1",
-							Type: "complex.test.com",
-							Inputs: []MappingEntry{
-								{Source: "input1", Target: "target1"},
-								{Source: "input2", Target: "target2"},
-							},
+							ID:        "complex1",
+							Type:      "complex.test.com",
 							DependsOn: []string{"dependency1", "dependency2"},
 						},
 					},
@@ -618,9 +614,6 @@ func TestGetNextActivities(t *testing.T) {
 						{
 							ID:   "complex2",
 							Type: "another.complex.test.com",
-							Inputs: []MappingEntry{
-								{Source: "input3", Target: "target3"},
-							},
 						},
 					},
 				},
@@ -631,9 +624,6 @@ func TestGetNextActivities(t *testing.T) {
 		require.Len(t, activities, 1)
 		require.Equal(t, "complex2", activities[0].ID)
 		require.Equal(t, "another.complex.test.com", activities[0].Type.String())
-		require.Len(t, activities[0].Inputs, 1)
-		require.Equal(t, "input3", activities[0].Inputs[0].Source)
-		require.Equal(t, "target3", activities[0].Inputs[0].Target)
 	})
 }
 

--- a/pmanager/core/definition_manager.go
+++ b/pmanager/core/definition_manager.go
@@ -54,9 +54,11 @@ func (d definitionManager) CreateOrchestrationDefinition(ctx context.Context, de
 		if len(missingErrors) > 0 {
 			return nil, errors.Join(missingErrors...)
 		}
-		// Verify schema compatibility between dependent activities
-		if err := validateActivitySchema(definition.Activities, activityDefinitions); err != nil {
-			return nil, err
+		// Verify schema compatibility between dependent activities for deploy orchestrations
+		if definition.Type == model.VPADeployType {
+			if err := validateActivitySchema(definition.Activities, activityDefinitions); err != nil {
+				return nil, err
+			}
 		}
 
 		persisted, err := d.store.StoreOrchestrationDefinition(ctx, definition)

--- a/pmanager/core/definition_manager.go
+++ b/pmanager/core/definition_manager.go
@@ -199,9 +199,6 @@ func validateActivitySchema(activities []api.Activity, activityDefinitions map[a
 	var validationErrors []error
 
 	for _, activity := range activities {
-		if len(activity.DependsOn) == 0 {
-			continue
-		}
 
 		mergedDependantOutputProperties := make(map[string]any)
 
@@ -210,7 +207,7 @@ func validateActivitySchema(activities []api.Activity, activityDefinitions map[a
 		mergedDependantOutputProperties[model.VPAData] = map[string]any{"type": "array"}
 		mergedDependantOutputProperties[model.CredentialData] = map[string]any{"type": "array"}
 
-		mergeError := false
+		hasDuplicateFieldError := false
 
 		for _, dependencyID := range activity.DependsOn {
 			dependantActivity := activityMapById[dependencyID]
@@ -222,13 +219,13 @@ func validateActivitySchema(activities []api.Activity, activityDefinitions map[a
 			for field := range dependantOutputProperties {
 				if _, exists := mergedDependantOutputProperties[field]; exists {
 					validationErrors = append(validationErrors, types.NewValidationError(activity.ID, fmt.Sprintf("field %s is duplicated in multiple dependent activities", field)))
-					mergeError = true
+					hasDuplicateFieldError = true
 				} else {
 					mergedDependantOutputProperties[field] = dependantOutputProperties[field]
 				}
 			}
 		}
-		if mergeError {
+		if hasDuplicateFieldError {
 			continue
 		}
 

--- a/pmanager/core/definition_manager.go
+++ b/pmanager/core/definition_manager.go
@@ -15,9 +15,11 @@ package core
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/eclipse-cfm/cfm/common/collection"
+	"github.com/eclipse-cfm/cfm/common/model"
 	"github.com/eclipse-cfm/cfm/common/query"
 	"github.com/eclipse-cfm/cfm/common/store"
 	"github.com/eclipse-cfm/cfm/common/types"
@@ -34,19 +36,27 @@ func (d definitionManager) CreateOrchestrationDefinition(ctx context.Context, de
 	return store.Trx[api.OrchestrationDefinition](d.trxContext).AndReturn(ctx, func(ctx context.Context) (*api.OrchestrationDefinition, error) {
 		var missingErrors []error
 
+		activityDefinitions := make(map[api.ActivityType]*api.ActivityDefinition)
+
 		// Verify that all referenced activities exist
 		for _, activity := range definition.Activities {
-			exists, err := d.store.ExistsActivityDefinition(ctx, activity.Type)
+			activityDefinition, err := d.store.FindActivityDefinition(ctx, activity.Type)
 			if err != nil {
+				if errors.Is(err, types.ErrNotFound) {
+					missingErrors = append(missingErrors, types.NewClientError("activity type '%s' not found", activity.Type))
+					continue
+				}
 				return nil, err
 			}
-			if !exists {
-				missingErrors = append(missingErrors, types.NewClientError("activity type '%s' not found", activity.Type))
-			}
+			activityDefinitions[activity.Type] = activityDefinition
 		}
 
 		if len(missingErrors) > 0 {
 			return nil, errors.Join(missingErrors...)
+		}
+		// Verify schema compatibility between dependent activities
+		if err := validateActivitySchema(definition.Activities, activityDefinitions); err != nil {
+			return nil, err
 		}
 
 		persisted, err := d.store.StoreOrchestrationDefinition(ctx, definition)
@@ -177,4 +187,80 @@ func (d definitionManager) GetActivityDefinitions(ctx context.Context) ([]api.Ac
 		return nil
 	})
 	return result, err
+}
+
+func validateActivitySchema(activities []api.Activity, activityDefinitions map[api.ActivityType]*api.ActivityDefinition) error {
+	activityMapById := make(map[string]api.Activity)
+
+	for _, activity := range activities {
+		activityMapById[activity.ID] = activity
+	}
+
+	var validationErrors []error
+
+	for _, activity := range activities {
+		if len(activity.DependsOn) == 0 {
+			continue
+		}
+
+		mergedDependantOutputProperties := make(map[string]any)
+
+		//The following 3 fields are always injected as part of the orchestration manifest. In a future this could be modified and maybe derived from the orchestration schema
+		mergedDependantOutputProperties[model.ParticipantIdentifier] = map[string]any{"type": "string"}
+		mergedDependantOutputProperties[model.VPAData] = map[string]any{"type": "array"}
+		mergedDependantOutputProperties[model.CredentialData] = map[string]any{"type": "array"}
+
+		mergeError := false
+
+		for _, dependencyID := range activity.DependsOn {
+			dependantActivity := activityMapById[dependencyID]
+			dependantActivityDefinition := activityDefinitions[dependantActivity.Type]
+			dependantOutputProperties, ok := dependantActivityDefinition.OutputSchema["properties"].(map[string]any)
+			if !ok {
+				continue
+			}
+			for field := range dependantOutputProperties {
+				if _, exists := mergedDependantOutputProperties[field]; exists {
+					validationErrors = append(validationErrors, types.NewValidationError(activity.ID, fmt.Sprintf("field %s is duplicated in multiple dependent activities", field)))
+					mergeError = true
+				} else {
+					mergedDependantOutputProperties[field] = dependantOutputProperties[field]
+				}
+			}
+		}
+		if mergeError {
+			continue
+		}
+
+		requiredFields, _ := activityDefinitions[activity.Type].InputSchema["required"].([]any)
+		inputProperties, _ := activityDefinitions[activity.Type].InputSchema["properties"].(map[string]any)
+
+		for _, required := range requiredFields {
+			field, ok := required.(string)
+			if !ok {
+				continue
+			}
+
+			if _, exists := mergedDependantOutputProperties[field]; !exists {
+				validationErrors = append(validationErrors, types.NewValidationError(activity.ID, fmt.Sprintf("required input field %s is not provided by dependent activities as output", field)))
+			}
+		}
+
+		for field := range inputProperties {
+			dependantField, exists := mergedDependantOutputProperties[field]
+			if !exists {
+				continue
+			}
+			inputFieldType, _ := inputProperties[field].(map[string]any)["type"].(string)
+			dependantFieldType, _ := dependantField.(map[string]any)["type"].(string)
+
+			if inputFieldType != "" && dependantFieldType != "" && inputFieldType != dependantFieldType {
+				validationErrors = append(validationErrors, types.NewValidationError(activity.ID, fmt.Sprintf("type of input field %s differs from dependent activities output", field)))
+			}
+
+		}
+
+	}
+
+	return errors.Join(validationErrors...)
 }

--- a/pmanager/core/definition_manager.go
+++ b/pmanager/core/definition_manager.go
@@ -241,6 +241,10 @@ func validateActivitySchema(activities []api.Activity, activityDefinitions map[a
 			}
 
 			if _, exists := mergedDependantOutputProperties[field]; !exists {
+				if len(activity.DependsOn) == 0 {
+					validationErrors = append(validationErrors, types.NewValidationError(activity.ID, "activity has required input fields in InputSchema but not declared dependencies"))
+					break
+				}
 				validationErrors = append(validationErrors, types.NewValidationError(activity.ID, fmt.Sprintf("required input field %s is not provided by dependent activities as output", field)))
 			}
 		}

--- a/pmanager/core/definition_manager_test.go
+++ b/pmanager/core/definition_manager_test.go
@@ -894,7 +894,7 @@ func TestValidateActivitySchema_Success(t *testing.T) {
 		},
 		"type-b": {
 			Type: "type-b",
-			OutputSchema: map[string]any{
+			InputSchema: map[string]any{
 				"properties": map[string]any{
 					"field-a": map[string]any{"type": "string"},
 				},
@@ -964,7 +964,34 @@ func TestValidateActivitySchema_DuplicatedFields(t *testing.T) {
 	assert.Contains(t, err.Error(), "field field-1 is duplicated in multiple dependent activities")
 }
 
-func TestValidateActivitySchema_IncompatibleFieldTypes(t *testing.T) {
+func TestValidateActivitySchema_IncompatibleRequiredFieldTypes(t *testing.T) {
+	activities := []api.Activity{
+		{ID: "activity-a", Type: "type-a", DependsOn: []string{}},
+		{ID: "activity-b", Type: "type-b", DependsOn: []string{"activity-a"}},
+	}
+	activityDefinitions := map[api.ActivityType]*api.ActivityDefinition{
+		"type-a": {
+			OutputSchema: map[string]any{
+				"properties": map[string]any{
+					"field-a": map[string]any{"type": "string"},
+				},
+			},
+		},
+		"type-b": {
+			InputSchema: map[string]any{
+				"properties": map[string]any{
+					"field-a": map[string]any{"type": "array"},
+				},
+				"required": []any{"field-a"},
+			},
+		},
+	}
+	err := validateActivitySchema(activities, activityDefinitions)
+	require.Error(t, err, "Type missmatch in Required Output and Input Field")
+	assert.Contains(t, err.Error(), "type of input field field-a differs from dependent activities output")
+}
+
+func TestValidateActivitySchema_IncompatibleOptionalFieldTypes(t *testing.T) {
 	activities := []api.Activity{
 		{ID: "activity-a", Type: "type-a", DependsOn: []string{}},
 		{ID: "activity-b", Type: "type-b", DependsOn: []string{"activity-a"}},
@@ -986,8 +1013,100 @@ func TestValidateActivitySchema_IncompatibleFieldTypes(t *testing.T) {
 		},
 	}
 	err := validateActivitySchema(activities, activityDefinitions)
-	require.Error(t, err, "Type missmatch in Output and Input Field")
+	require.Error(t, err, "Type missmatch in Optional Output and Input Field")
 	assert.Contains(t, err.Error(), "type of input field field-a differs from dependent activities output")
+}
+
+func TestValidateActivitySchema_OptionalFieldMissing(t *testing.T) {
+	activities := []api.Activity{
+		{ID: "activity-a", Type: "type-a", DependsOn: []string{}},
+		{ID: "activity-b", Type: "type-b", DependsOn: []string{"activity-a"}},
+	}
+	activityDefinitions := map[api.ActivityType]*api.ActivityDefinition{
+		"type-a": {
+			OutputSchema: map[string]any{},
+		},
+		"type-b": {
+			InputSchema: map[string]any{
+				"properties": map[string]any{
+					"field-a": map[string]any{"type": "string"},
+				},
+			},
+		},
+	}
+	err := validateActivitySchema(activities, activityDefinitions)
+	require.NoError(t, err, "Validation should succeed")
+}
+
+func TestValidateActivitySchema_TransitiveDependency(t *testing.T) {
+	activities := []api.Activity{
+		{ID: "activity-a", Type: "type-a", DependsOn: []string{}},
+		{ID: "activity-b", Type: "type-b", DependsOn: []string{}},
+		{ID: "activity-c", Type: "type-c", DependsOn: []string{"activity-a", "activity-b"}},
+	}
+	activityDefinitions := map[api.ActivityType]*api.ActivityDefinition{
+		"type-a": {
+			OutputSchema: map[string]any{
+				"properties": map[string]any{
+					"field-1": map[string]any{"type": "string"},
+				},
+			},
+		},
+		"type-b": {
+			OutputSchema: map[string]any{
+				"properties": map[string]any{
+					"field-2": map[string]any{"type": "string"},
+				},
+			},
+		},
+		"type-c": {
+			InputSchema: map[string]any{
+				"properties": map[string]any{
+					"field-1": map[string]any{"type": "string"},
+					"field-2": map[string]any{"type": "string"},
+				},
+				"required": []any{"field-1", "field-2"},
+			},
+		},
+	}
+	err := validateActivitySchema(activities, activityDefinitions)
+	require.NoError(t, err, "Validation should succeed")
+}
+
+func TestValidateActivitySchema_TransitiveDependencyNotDeclared(t *testing.T) {
+	activities := []api.Activity{
+		{ID: "activity-a", Type: "type-a", DependsOn: []string{}},
+		{ID: "activity-b", Type: "type-b", DependsOn: []string{}},
+		{ID: "activity-c", Type: "type-c", DependsOn: []string{"activity-b"}},
+	}
+	activityDefinitions := map[api.ActivityType]*api.ActivityDefinition{
+		"type-a": {
+			OutputSchema: map[string]any{
+				"properties": map[string]any{
+					"field-1": map[string]any{"type": "string"},
+				},
+			},
+		},
+		"type-b": {
+			OutputSchema: map[string]any{
+				"properties": map[string]any{
+					"field-2": map[string]any{"type": "string"},
+				},
+			},
+		},
+		"type-c": {
+			InputSchema: map[string]any{
+				"properties": map[string]any{
+					"field-1": map[string]any{"type": "string"},
+					"field-2": map[string]any{"type": "string"},
+				},
+				"required": []any{"field-1", "field-2"},
+			},
+		},
+	}
+	err := validateActivitySchema(activities, activityDefinitions)
+	require.Error(t, err, "Transitive dependency not declared")
+	assert.Contains(t, err.Error(), "required input field field-1 is not provided by dependent activities as output")
 }
 
 // Helper mock store for testing error scenarios

--- a/pmanager/core/definition_manager_test.go
+++ b/pmanager/core/definition_manager_test.go
@@ -59,7 +59,6 @@ func TestCreateOrchestrationDefinition_Success(t *testing.T) {
 			{
 				ID:        "activity-1",
 				Type:      "test-activity",
-				Inputs:    []api.MappingEntry{{Source: "input1", Target: "target1"}},
 				DependsOn: []string{},
 			},
 		},
@@ -92,7 +91,6 @@ func TestCreateOrchestrationDefinition_MissingActivityDefinition(t *testing.T) {
 			{
 				ID:        "activity-1",
 				Type:      "non-existent-activity", // This activity definition doesn't exist
-				Inputs:    []api.MappingEntry{{Source: "input1", Target: "target1"}},
 				DependsOn: []string{},
 			},
 		},
@@ -137,19 +135,16 @@ func TestCreateOrchestrationDefinition_MultipleMissingActivityDefinitions(t *tes
 			{
 				ID:        "activity-1",
 				Type:      "valid-activity", // This exists
-				Inputs:    []api.MappingEntry{{Source: "input1", Target: "target1"}},
 				DependsOn: []string{},
 			},
 			{
 				ID:        "activity-2",
 				Type:      "missing-activity-1", // This doesn't exist
-				Inputs:    []api.MappingEntry{{Source: "input2", Target: "target2"}},
 				DependsOn: []string{"activity-1"},
 			},
 			{
 				ID:        "activity-3",
 				Type:      "missing-activity-2", // This also doesn't exist
-				Inputs:    []api.MappingEntry{{Source: "input3", Target: "target3"}},
 				DependsOn: []string{"activity-1"},
 			},
 		},
@@ -309,13 +304,11 @@ func TestIntegration_CompleteWorkflow(t *testing.T) {
 			{
 				ID:        "prepare-step",
 				Type:      "prepare",
-				Inputs:    []api.MappingEntry{{Source: "config", Target: "configuration"}},
 				DependsOn: []string{},
 			},
 			{
 				ID:        "orchestration-step",
 				Type:      "deploy",
-				Inputs:    []api.MappingEntry{{Source: "artifact", Target: "deployment_artifact"}},
 				DependsOn: []string{"prepare-step"},
 			},
 		},
@@ -668,7 +661,6 @@ func TestDeleteActivityDefinition_ReferencedByOrchestration(t *testing.T) {
 			{
 				ID:        "activity-1",
 				Type:      activityDef.Type,
-				Inputs:    []api.MappingEntry{{Source: "input1", Target: "target1"}},
 				DependsOn: []string{},
 			},
 		},
@@ -794,7 +786,6 @@ func TestDeleteActivityDefinition_MultipleReferences(t *testing.T) {
 			{
 				ID:        "activity-1",
 				Type:      activityDef.Type,
-				Inputs:    []api.MappingEntry{{Source: "input", Target: "output"}},
 				DependsOn: []string{},
 			},
 		},
@@ -811,7 +802,6 @@ func TestDeleteActivityDefinition_MultipleReferences(t *testing.T) {
 			{
 				ID:        "activity-2",
 				Type:      activityDef.Type,
-				Inputs:    []api.MappingEntry{{Source: "input", Target: "output"}},
 				DependsOn: []string{},
 			},
 		},
@@ -855,7 +845,6 @@ func TestDeleteActivityDefinition_AfterOrchestrationDeletion(t *testing.T) {
 			{
 				ID:        "activity-1",
 				Type:      activityDef.Type,
-				Inputs:    []api.MappingEntry{{Source: "input", Target: "output"}},
 				DependsOn: []string{},
 			},
 		},
@@ -879,6 +868,126 @@ func TestDeleteActivityDefinition_AfterOrchestrationDeletion(t *testing.T) {
 	exists, err := store.ExistsActivityDefinition(ctx, activityDef.Type)
 	require.NoError(t, err, "Failed to check existence")
 	assert.False(t, exists, "Activity definition should no longer exist")
+}
+
+func TestValidateActivitySchema_Success(t *testing.T) {
+	activities := []api.Activity{
+		{
+			ID:        "activity-a",
+			Type:      "type-a",
+			DependsOn: []string{},
+		},
+		{
+			ID:        "activity-b",
+			Type:      "type-b",
+			DependsOn: []string{"activity-a"},
+		},
+	}
+	activityDefinitions := map[api.ActivityType]*api.ActivityDefinition{
+		"type-a": {
+			Type: "type-a",
+			OutputSchema: map[string]any{
+				"properties": map[string]any{
+					"field-a": map[string]any{"type": "string"},
+				},
+			},
+		},
+		"type-b": {
+			Type: "type-b",
+			OutputSchema: map[string]any{
+				"properties": map[string]any{
+					"field-a": map[string]any{"type": "string"},
+				},
+				"required": []any{"field-a"},
+			},
+		},
+	}
+	err := validateActivitySchema(activities, activityDefinitions)
+	require.NoError(t, err)
+}
+
+func TestValidateActivitySchema_MissingRequiredField(t *testing.T) {
+	activities := []api.Activity{
+		{ID: "activity-a", Type: "type-a", DependsOn: []string{}},
+		{ID: "activity-b", Type: "type-b", DependsOn: []string{"activity-a"}},
+	}
+	activityDefinitions := map[api.ActivityType]*api.ActivityDefinition{
+		"type-a": {
+			OutputSchema: map[string]any{
+				"properties": map[string]any{},
+			},
+		},
+		"type-b": {
+			InputSchema: map[string]any{
+				"properties": map[string]any{
+					"field-a": map[string]any{"type": "string"},
+				},
+				"required": []any{"field-a"},
+			},
+		},
+	}
+	err := validateActivitySchema(activities, activityDefinitions)
+	require.Error(t, err, "Missing required field-a")
+	assert.Contains(t, err.Error(), "required input field field-a")
+}
+func TestValidateActivitySchema_DuplicatedFields(t *testing.T) {
+	activities := []api.Activity{
+		{ID: "activity-a", Type: "type-a", DependsOn: []string{}},
+		{ID: "activity-b", Type: "type-b", DependsOn: []string{}},
+		{ID: "activity-c", Type: "type-c", DependsOn: []string{"activity-a", "activity-b"}},
+	}
+	activityDefinitions := map[api.ActivityType]*api.ActivityDefinition{
+		"type-a": {
+			OutputSchema: map[string]any{
+				"properties": map[string]any{
+					"field-1": map[string]any{"type": "string"},
+				},
+			},
+		},
+		"type-b": {
+			OutputSchema: map[string]any{
+				"properties": map[string]any{
+					"field-1": map[string]any{"type": "string"},
+				},
+			},
+		},
+		"type-c": {
+			InputSchema: map[string]any{
+				"properties": map[string]any{
+					"field-1": map[string]any{"type": "string"},
+				},
+			},
+		},
+	}
+	err := validateActivitySchema(activities, activityDefinitions)
+	require.Error(t, err, "Field defined by multiple output schemas")
+	assert.Contains(t, err.Error(), "field field-1 is duplicated in multiple dependent activities")
+}
+
+func TestValidateActivitySchema_IncompatibleFieldTypes(t *testing.T) {
+	activities := []api.Activity{
+		{ID: "activity-a", Type: "type-a", DependsOn: []string{}},
+		{ID: "activity-b", Type: "type-b", DependsOn: []string{"activity-a"}},
+	}
+	activityDefinitions := map[api.ActivityType]*api.ActivityDefinition{
+		"type-a": {
+			OutputSchema: map[string]any{
+				"properties": map[string]any{
+					"field-a": map[string]any{"type": "string"},
+				},
+			},
+		},
+		"type-b": {
+			InputSchema: map[string]any{
+				"properties": map[string]any{
+					"field-a": map[string]any{"type": "array"},
+				},
+			},
+		},
+	}
+	err := validateActivitySchema(activities, activityDefinitions)
+	require.Error(t, err, "Type missmatch in Output and Input Field")
+	assert.Contains(t, err.Error(), "type of input field field-a differs from dependent activities output")
 }
 
 // Helper mock store for testing error scenarios

--- a/pmanager/core/definition_manager_test.go
+++ b/pmanager/core/definition_manager_test.go
@@ -1109,6 +1109,25 @@ func TestValidateActivitySchema_TransitiveDependencyNotDeclared(t *testing.T) {
 	assert.Contains(t, err.Error(), "required input field field-1 is not provided by dependent activities as output")
 }
 
+func TestValidateActivitySchema_RequiredFieldsButNoDependencies(t *testing.T) {
+	activities := []api.Activity{
+		{ID: "activity-a", Type: "type-a", DependsOn: []string{}},
+	}
+	activityDefinitions := map[api.ActivityType]*api.ActivityDefinition{
+		"type-a": {
+			InputSchema: map[string]any{
+				"properties": map[string]any{
+					"field-1": map[string]any{"type": "string"},
+				},
+				"required": []any{"field-1"},
+			},
+		},
+	}
+	err := validateActivitySchema(activities, activityDefinitions)
+	require.Error(t, err, "No dependency declared but additional fields in InputSchema required")
+	assert.Contains(t, err.Error(), "activity has required input fields in InputSchema but not declared dependencies")
+}
+
 // Helper mock store for testing error scenarios
 type mockDefinitionStore struct {
 	simulatedErrors map[string]error

--- a/pmanager/model/v1alpha1/model.go
+++ b/pmanager/model/v1alpha1/model.go
@@ -30,15 +30,9 @@ type ActivityDefinitionDto struct {
 }
 
 type ActivityDto struct {
-	ID        string         `json:"id" validate:"required"`
-	Type      string         `json:"type" validate:"required,modeltype"`
-	Inputs    []MappingEntry `json:"inputs,omitempty"`
-	DependsOn []string       `json:"dependsOn,omitempty"`
-}
-
-type MappingEntry struct {
-	Source string `json:"source" validate:"required"`
-	Target string `json:"target" validate:"required"`
+	ID        string   `json:"id" validate:"required"`
+	Type      string   `json:"type" validate:"required,modeltype"`
+	DependsOn []string `json:"dependsOn,omitempty"`
 }
 
 type OrchestrationDefinitionDto struct {

--- a/pmanager/model/v1alpha1/transformers.go
+++ b/pmanager/model/v1alpha1/transformers.go
@@ -77,7 +77,6 @@ func ToOrchestrationDefinition(template *OrchestrationTemplate) (string, []*api.
 				ID:            activityDto.ID,
 				Type:          api.ActivityType(activityDto.Type),
 				Discriminator: api.Discriminator(orchType),
-				Inputs:        ToAPIMappingEntries(activityDto.Inputs),
 				DependsOn:     activityDto.DependsOn,
 			}
 			convertedActivities[i] = activity
@@ -110,7 +109,6 @@ func ToOrchestrationDefinitionDto(definition *api.OrchestrationDefinition) *Orch
 		convertedActivities[activity.Discriminator.String()] = append(convertedActivities[activity.Discriminator.String()], ActivityDto{
 			ID:        activity.ID,
 			Type:      string(activity.Type),
-			Inputs:    ToMappingEntries(activity.Inputs),
 			DependsOn: activity.DependsOn,
 		})
 	}
@@ -121,28 +119,6 @@ func ToOrchestrationDefinitionDto(definition *api.OrchestrationDefinition) *Orch
 		Activities:  convertedActivities,
 		TemplateRef: definition.TemplateRef,
 	}
-}
-
-func ToAPIMappingEntries(entries []MappingEntry) []api.MappingEntry {
-	apiEntries := make([]api.MappingEntry, len(entries))
-	for i, entry := range entries {
-		apiEntries[i] = api.MappingEntry{
-			Source: entry.Source,
-			Target: entry.Target,
-		}
-	}
-	return apiEntries
-}
-
-func ToMappingEntries(entries []api.MappingEntry) []MappingEntry {
-	apiEntries := make([]MappingEntry, len(entries))
-	for i, entry := range entries {
-		apiEntries[i] = MappingEntry{
-			Source: entry.Source,
-			Target: entry.Target,
-		}
-	}
-	return apiEntries
 }
 
 func ToOrchestrationEntry(entry *api.OrchestrationEntry) OrchestrationEntry {
@@ -189,19 +165,7 @@ func toActivities(activities []api.Activity) []ActivityDto {
 		result[i] = ActivityDto{
 			ID:        activity.ID,
 			Type:      string(activity.Type),
-			Inputs:    toMappingEntries(activity.Inputs),
 			DependsOn: activity.DependsOn,
-		}
-	}
-	return result
-}
-
-func toMappingEntries(entries []api.MappingEntry) []MappingEntry {
-	result := make([]MappingEntry, len(entries))
-	for i, entry := range entries {
-		result[i] = MappingEntry{
-			Source: entry.Source,
-			Target: entry.Target,
 		}
 	}
 	return result

--- a/pmanager/model/v1alpha1/transformers_test.go
+++ b/pmanager/model/v1alpha1/transformers_test.go
@@ -95,19 +95,14 @@ func TestToOrchestrationDefinition(t *testing.T) {
 				Activities: map[string][]ActivityDto{
 					"foo.bar.kubernetes": {
 						{
-							ID:   "activity-1",
-							Type: "http-request",
-							Inputs: []MappingEntry{
-								{Source: "input.url", Target: "request.url"},
-								{Source: "input.method", Target: "request.method"},
-							},
+							ID:        "activity-1",
+							Type:      "http-request",
 							DependsOn: []string{"activity-0"},
 						},
 					},
 					DefaultActivityDiscriminator: {{
 						ID:        "activity-2",
 						Type:      "data-transform",
-						Inputs:    []MappingEntry{},
 						DependsOn: []string{"activity-1"},
 					}},
 				},
@@ -124,11 +119,7 @@ func TestToOrchestrationDefinition(t *testing.T) {
 							ID:            "activity-1",
 							Type:          api.ActivityType("http-request"),
 							Discriminator: "foo.bar.kubernetes",
-							Inputs: []api.MappingEntry{
-								{Source: "input.url", Target: "request.url"},
-								{Source: "input.method", Target: "request.method"},
-							},
-							DependsOn: []string{"activity-0"},
+							DependsOn:     []string{"activity-0"},
 						},
 					},
 				},
@@ -143,7 +134,6 @@ func TestToOrchestrationDefinition(t *testing.T) {
 							ID:            "activity-2",
 							Discriminator: DefaultActivityDiscriminator,
 							Type:          api.ActivityType("data-transform"),
-							Inputs:        []api.MappingEntry{},
 							DependsOn:     []string{"activity-1"},
 						},
 					},
@@ -177,9 +167,6 @@ func TestToOrchestrationDefinition(t *testing.T) {
 					"local": {{
 						ID:   "standalone-activity",
 						Type: "file-processor",
-						Inputs: []MappingEntry{
-							{Source: "file.path", Target: "processor.input"},
-						},
 					}},
 				},
 			},
@@ -192,9 +179,6 @@ func TestToOrchestrationDefinition(t *testing.T) {
 						ID:            "standalone-activity",
 						Type:          api.ActivityType("file-processor"),
 						Discriminator: "local",
-						Inputs: []api.MappingEntry{
-							{Source: "file.path", Target: "processor.input"},
-						},
 					},
 				},
 			},
@@ -219,89 +203,6 @@ func TestToAPIOrchestrationDefinition_NilInput(t *testing.T) {
 	})
 }
 
-func TestToAPIMappingEntries(t *testing.T) {
-	tests := []struct {
-		name     string
-		entries  []MappingEntry
-		expected []api.MappingEntry
-	}{
-		{
-			name: "multiple mapping entries",
-			entries: []MappingEntry{
-				{Source: "input.name", Target: "output.fullName"},
-				{Source: "input.age", Target: "output.yearsOld"},
-				{Source: "input.email", Target: "output.contactEmail"},
-			},
-			expected: []api.MappingEntry{
-				{Source: "input.name", Target: "output.fullName"},
-				{Source: "input.age", Target: "output.yearsOld"},
-				{Source: "input.email", Target: "output.contactEmail"},
-			},
-		},
-		{
-			name: "single mapping entry",
-			entries: []MappingEntry{
-				{Source: "data.value", Target: "result.processed"},
-			},
-			expected: []api.MappingEntry{
-				{Source: "data.value", Target: "result.processed"},
-			},
-		},
-		{
-			name:     "empty mapping entries",
-			entries:  []MappingEntry{},
-			expected: []api.MappingEntry{},
-		},
-		{
-			name: "mapping entries with empty strings",
-			entries: []MappingEntry{
-				{Source: "", Target: ""},
-				{Source: "valid.source", Target: ""},
-				{Source: "", Target: "valid.target"},
-			},
-			expected: []api.MappingEntry{
-				{Source: "", Target: ""},
-				{Source: "valid.source", Target: ""},
-				{Source: "", Target: "valid.target"},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := ToAPIMappingEntries(tt.entries)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestToAPIMappingEntries_NilInput(t *testing.T) {
-	result := ToAPIMappingEntries(nil)
-	assert.NotNil(t, result)
-	assert.Len(t, result, 0)
-}
-
-func TestToOrchestrationEntry_VerifiesInputs(t *testing.T) {
-	testTime := time.Now()
-	input := api.OrchestrationEntry{
-		ID:                "test-id-123",
-		CorrelationID:     "corr-id-456",
-		State:             5,
-		StateTimestamp:    testTime,
-		CreatedTimestamp:  testTime.Add(-time.Hour),
-		OrchestrationType: model.OrchestrationType("TestType"),
-	}
-
-	result := ToOrchestrationEntry(&input)
-
-	assert.Equal(t, input.ID, result.ID)
-	assert.Equal(t, input.CorrelationID, result.CorrelationID)
-	assert.Equal(t, int(input.State), result.State)
-	assert.Equal(t, input.StateTimestamp, result.StateTimestamp)
-	assert.Equal(t, input.CreatedTimestamp, result.CreatedTimestamp)
-	assert.Equal(t, input.OrchestrationType, result.OrchestrationType)
-}
-
 func TestToOrchestration(t *testing.T) {
 	now := time.Now()
 	apiOrchestration := &api.Orchestration{
@@ -321,10 +222,7 @@ func TestToOrchestration(t *testing.T) {
 						ID:            "activity-1",
 						Type:          "test.activity",
 						Discriminator: "test-disc",
-						Inputs: []api.MappingEntry{
-							{Source: "src1", Target: "tgt1"},
-						},
-						DependsOn: []string{"activity-0"},
+						DependsOn:     []string{"activity-0"},
 					},
 				},
 			},
@@ -345,8 +243,6 @@ func TestToOrchestration(t *testing.T) {
 	assert.Equal(t, 1, len(result.Steps[0].Activities))
 	assert.Equal(t, "activity-1", result.Steps[0].Activities[0].ID)
 	assert.Equal(t, "test.activity", result.Steps[0].Activities[0].Type)
-	assert.Equal(t, 1, len(result.Steps[0].Activities[0].Inputs))
-	assert.Equal(t, "src1", result.Steps[0].Activities[0].Inputs[0].Source)
 }
 
 func TestToActivityDefinition_WithValidDefinition(t *testing.T) {

--- a/pmanager/model/v1alpha1/transformers_test.go
+++ b/pmanager/model/v1alpha1/transformers_test.go
@@ -203,6 +203,27 @@ func TestToAPIOrchestrationDefinition_NilInput(t *testing.T) {
 	})
 }
 
+func TestToOrchestrationEntry_VerifiesInputs(t *testing.T) {
+	testTime := time.Now()
+	input := api.OrchestrationEntry{
+		ID:                "test-id-123",
+		CorrelationID:     "corr-id-456",
+		State:             5,
+		StateTimestamp:    testTime,
+		CreatedTimestamp:  testTime.Add(-time.Hour),
+		OrchestrationType: model.OrchestrationType("TestType"),
+	}
+
+	result := ToOrchestrationEntry(&input)
+
+	assert.Equal(t, input.ID, result.ID)
+	assert.Equal(t, input.CorrelationID, result.CorrelationID)
+	assert.Equal(t, int(input.State), result.State)
+	assert.Equal(t, input.StateTimestamp, result.StateTimestamp)
+	assert.Equal(t, input.CreatedTimestamp, result.CreatedTimestamp)
+	assert.Equal(t, input.OrchestrationType, result.OrchestrationType)
+}
+
 func TestToOrchestration(t *testing.T) {
 	now := time.Now()
 	apiOrchestration := &api.Orchestration{


### PR DESCRIPTION
This PR adds schema validation in the creation of new orchestration definitions (API) by validating that the output schemas of dependent activities are compatible with the input schema of the dependent activity. Only top-level fields are validated and a full deep validation should be performed at runtime. The following validations have been implemented:
- Check that the aggregated output of the dependencies provides all required fields of the dependent activity's input schema
- Check that the outputs of the dependencies have no duplicate field names 
- Check that the field types in the output and input schemas match

This PR also removes for simplification the `Activity.input `mappings from the `Activity` and `ActivityDTO` structs that were defined but never used.