### PR TITLE
feat: extract IdentityHub logic into a dedicated ih-agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ COMMON_DIR=common
 PMANAGER_DIR=pmanager
 TMANAGER_DIR=tmanager
 EDCV_DIR=agent/edcv
+IH_DIR=agent/ih
 KEYCLOAK_DIR=agent/keycloak
 REG_DIR=agent/registration
 ONBOARDING_DIR=agent/onboarding
@@ -66,6 +67,7 @@ build:
 	$(MAKE) -C $(PMANAGER_DIR) build
 	$(MAKE) -C $(TMANAGER_DIR) build
 	$(MAKE) -C $(EDCV_DIR) build
+	$(MAKE) -C $(IH_DIR) build
 	$(MAKE) -C $(KEYCLOAK_DIR) build
 	$(MAKE) -C $(REG_DIR) build
 	$(MAKE) -C $(ONBOARDING_DIR) build
@@ -83,6 +85,7 @@ build-all:
 	$(MAKE) -C $(PMANAGER_DIR) build-all
 	$(MAKE) -C $(TMANAGER_DIR) build-all
 	$(MAKE) -C $(EDCV_DIR) build-all
+	$(MAKE) -C $(IH_DIR) build-all
 	$(MAKE) -C $(KEYCLOAK_DIR) build-all
 	$(MAKE) -C $(REG_DIR) build-all
 	$(MAKE) -C $(ONBOARDING_DIR) build-all
@@ -97,6 +100,7 @@ test: install-gotestsum
 	$(MAKE) -C $(PMANAGER_DIR) test
 	$(MAKE) -C $(TMANAGER_DIR) test
 	$(MAKE) -C $(EDCV_DIR) test
+	$(MAKE) -C $(IH_DIR) test
 	$(MAKE) -C $(E2E_DIR) test
 	$(MAKE) -C $(KEYCLOAK_DIR) test
 	$(MAKE) -C $(REG_DIR) test
@@ -150,6 +154,7 @@ clean:
 	$(MAKE) -C $(PMANAGER_DIR) clean
 	$(MAKE) -C $(TMANAGER_DIR) clean
 	$(MAKE) -C $(EDCV_DIR) clean
+	$(MAKE) -C $(IH_DIR) clean
 	$(MAKE) -C $(REG_DIR) clean
 	$(MAKE) -C $(ONBOARDING_DIR) clean
 
@@ -182,7 +187,7 @@ generate-docs:
 # Docker Commands - Handled at Top Level
 #==============================================================================
 
-docker-build: docker-build-pmanager docker-build-tmanager docker-build-testagent docker-build-edcvagent docker-build-kcagent docker-build-regagent docker-build-obagent
+docker-build: docker-build-pmanager docker-build-tmanager docker-build-testagent docker-build-edcvagent docker-build-ihagent docker-build-kcagent docker-build-regagent docker-build-obagent
 
 docker-build-pmanager:
 	@echo "Building pmanager Docker image..."
@@ -200,6 +205,10 @@ docker-build-edcvagent:
 	@echo "Building EDC-V agent Docker image..."
 	docker buildx build -f docker/Dockerfile.edcvagent.dockerfile -t $(DOCKER_REGISTRY)edcvagent:$(DOCKER_TAG) .
 
+docker-build-ihagent:
+	@echo "Building IdentityHub agent Docker image..."
+	docker buildx build -f docker/Dockerfile.ihagent.dockerfile -t $(DOCKER_REGISTRY)ihagent:$(DOCKER_TAG) .
+
 docker-build-kcagent:
 	@echo "Building Keycloak agent Docker image..."
 	docker buildx build -f docker/Dockerfile.kcagent.dockerfile -t $(DOCKER_REGISTRY)kcagent:$(DOCKER_TAG) .
@@ -212,7 +221,7 @@ docker-build-obagent:
 	@echo "Building Onboarding agent Docker image..."
 	docker buildx build -f docker/Dockerfile.obagent.dockerfile -t $(DOCKER_REGISTRY)obagent:$(DOCKER_TAG) .
 
-docker-clean: docker-clean-pmanager docker-clean-tmanager docker-clean-testagent docker-clean-regagent docker-clean-obagent
+docker-clean: docker-clean-pmanager docker-clean-tmanager docker-clean-testagent docker-clean-edcvagent docker-clean-ihagent docker-clean-regagent docker-clean-obagent
 
 docker-clean-pmanager:
 	docker rmi $(DOCKER_REGISTRY)pmanager:$(DOCKER_TAG) || true
@@ -225,6 +234,9 @@ docker-clean-testagent:
 
 docker-clean-edcvagent:
 	docker rmi $(DOCKER_REGISTRY)edcvagent:$(DOCKER_TAG) || true
+
+docker-clean-ihagent:
+	docker rmi $(DOCKER_REGISTRY)ihagent:$(DOCKER_TAG) || true
 
 docker-clean-regagent:
 	docker rmi $(DOCKER_REGISTRY)regagent:$(DOCKER_TAG) || true
@@ -244,6 +256,9 @@ load-into-kind-tmanager: docker-build-tmanager
 
 load-into-kind-edcvagent: docker-build-edcvagent
 	kind load docker-image -n $(KIND_CLUSTER_NAME) $(DOCKER_REGISTRY)edcvagent:$(DOCKER_TAG)
+
+load-into-kind-ihagent: docker-build-ihagent
+	kind load docker-image -n $(KIND_CLUSTER_NAME) $(DOCKER_REGISTRY)ihagent:$(DOCKER_TAG)
 
 load-into-kind-kcagent: docker-build-kcagent
 	kind load docker-image -n $(KIND_CLUSTER_NAME) $(DOCKER_REGISTRY)kcagent:$(DOCKER_TAG)

--- a/agent/common/identityhub/types.go
+++ b/agent/common/identityhub/types.go
@@ -17,7 +17,7 @@ package identityhub
 import (
 	"strings"
 
-	"github.com/eclipse-cfm/cfm/agent/edcv"
+	commonvault "github.com/eclipse-cfm/cfm/agent/common/vault"
 )
 
 const (
@@ -57,9 +57,9 @@ type ParticipantManifest struct {
 	// KeyGeneratorParameters the parameters used to generate the cryptographic key for the participant. Supplying a pre-generated key is not supported yet.
 	KeyGeneratorParameters KeyGeneratorParameters
 	// VaultConfig configuration for accessing a vault
-	VaultConfig edcv.VaultConfig
+	VaultConfig commonvault.Config
 	// VaultCredentials credentials which are needed to get a JWT which is used to access a vault
-	VaultCredentials edcv.VaultCredentials
+	VaultCredentials commonvault.Credentials
 }
 
 type CreateParticipantContextResponse struct {
@@ -89,7 +89,7 @@ func NewParticipantManifest(
 			KeyAlgorithm:    DefaultAlgorithm,
 			Curve:           DefaultCurve,
 		},
-		VaultConfig: edcv.VaultConfig{
+		VaultConfig: commonvault.Config{
 			SecretPath: "v1/participants",
 			FolderPath: participantContextID + "/identityhub",
 		},

--- a/agent/common/vault/types.go
+++ b/agent/common/vault/types.go
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package vault
+
+// Config defines configuration for accessing a vault, including its URL, secret path, and folder path.
+type Config struct {
+	// VaultURL the base URL of the vault
+	VaultURL string `json:"vaultUrl"`
+	// SecretPath the path of the mount point of the secret engine
+	SecretPath string `json:"secretPath"`
+	// FolderPath the path of the folder within the secret engine where the participant's manifest will be stored.
+	FolderPath string `json:"folderPath"`
+}
+
+// Credentials defines the credentials which are needed to get a JWT which is used to access a vault
+type Credentials struct {
+	// ClientID client ID of the service account of the IdP which is configured in Vault
+	ClientID string `json:"clientId"`
+	// ClientSecret secret of the service account of the IdP, which is configured in Vault
+	ClientSecret string `json:"clientSecret"`
+	// TokenURL URL of the token endpoint of the IdP which is configured in Vault
+	TokenURL string `json:"tokenUrl"`
+}

--- a/agent/edcv/activity/activity.go
+++ b/agent/edcv/activity/activity.go
@@ -15,36 +15,33 @@ package activity
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"strings"
 
-	"github.com/eclipse-cfm/cfm/agent/common/identityhub"
 	"github.com/eclipse-cfm/cfm/agent/edcv"
 	"github.com/eclipse-cfm/cfm/agent/edcv/controlplane"
 	"github.com/eclipse-cfm/cfm/assembly/serviceapi"
 	. "github.com/eclipse-cfm/cfm/common/collection"
 	"github.com/eclipse-cfm/cfm/common/system"
-	"github.com/eclipse-cfm/cfm/common/token"
 	"github.com/eclipse-cfm/cfm/pmanager/api"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
 
+const (
+	// STSClientIDKey is the context key written by the ih-agent and read here
+	STSClientIDKey = "ih.sts.clientId"
+)
+
 type EDCVActivityProcessor struct {
 	api.BaseActivityProcessor
-	VaultClient          serviceapi.VaultClient
-	HTTPClient           *http.Client
-	Monitor              system.LogMonitor
-	TokenProvider        token.TokenProvider
-	IdentityAPIClient    identityhub.IdentityAPIClient
-	TokenURL             string
-	VaultURL             string
-	STSTokenURL          string
-	CredentialServiceURL string
-	ProtocolServiceURL   string
-	ManagementAPIClient  controlplane.ManagementAPIClient
-	tracer               trace.Tracer
+	VaultClient         serviceapi.VaultClient
+	Monitor             system.LogMonitor
+	ManagementAPIClient controlplane.ManagementAPIClient
+	TokenURL            string
+	VaultURL            string
+	STSTokenURL         string
+	tracer              trace.Tracer
 }
 
 type edcData struct {
@@ -59,31 +56,23 @@ type edcData struct {
 
 func NewProcessor(config *Config) *EDCVActivityProcessor {
 	return &EDCVActivityProcessor{
-		VaultClient:          config.VaultClient,
-		HTTPClient:           config.Client,
-		Monitor:              config.LogMonitor,
-		IdentityAPIClient:    config.IdentityAPIClient,
-		ManagementAPIClient:  config.ManagementAPIClient,
-		TokenURL:             config.TokenURL,
-		VaultURL:             config.VaultURL,
-		STSTokenURL:          config.STSTokenURL,
-		CredentialServiceURL: config.CredentialServiceURL,
-		ProtocolServiceURL:   config.ProtocolServiceURL,
-		tracer:               otel.GetTracerProvider().Tracer("cfm.agent.edcv"),
+		VaultClient:         config.VaultClient,
+		Monitor:             config.LogMonitor,
+		ManagementAPIClient: config.ManagementAPIClient,
+		TokenURL:            config.TokenURL,
+		VaultURL:            config.VaultURL,
+		STSTokenURL:         config.STSTokenURL,
+		tracer:              otel.GetTracerProvider().Tracer("cfm.agent.edcv"),
 	}
 }
 
 type Config struct {
 	serviceapi.VaultClient
-	*http.Client
 	system.LogMonitor
-	identityhub.IdentityAPIClient
 	controlplane.ManagementAPIClient
-	TokenURL             string
-	VaultURL             string
-	STSTokenURL          string
-	CredentialServiceURL string
-	ProtocolServiceURL   string
+	TokenURL    string
+	VaultURL    string
+	STSTokenURL string
 }
 
 func (p EDCVActivityProcessor) ProcessDeploy(ctx api.ActivityContext) api.ActivityResult {
@@ -112,34 +101,28 @@ func (p EDCVActivityProcessor) ProcessDispose(ctx api.ActivityContext) api.Activ
 	return p.handleDisposeAction(ctx.Context(), data.ApiAccessClientID)
 }
 
-// handleDeployAction creates a participant context in IdentityHub and the control plane (incl. participant context config)
+// handleDeployAction creates the participant context and config in the EDC control plane.
+// It expects the STSClientID to already be present in the activity context (written by the ih-agent).
 func (p EDCVActivityProcessor) handleDeployAction(ctx api.ActivityContext, data edcData, participantContextId string) api.ActivityResult {
 
-	// override if config is provided
-	if p.CredentialServiceURL != "" {
-		data.CredentialServiceURL = fmt.Sprintf(p.CredentialServiceURL, participantContextId)
+	stsClientIDVal, ok := ctx.Value(STSClientIDKey)
+	if !ok || stsClientIDVal == nil {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("'%s' not found in activity context for orchestration %s — ensure the ih-agent runs before the edcv-agent", STSClientIDKey, ctx.OID())}
 	}
-	if p.ProtocolServiceURL != "" {
-		data.ProtocolServiceURL = fmt.Sprintf(p.ProtocolServiceURL, participantContextId)
-	}
-
-	if data.CredentialServiceURL == "" {
-		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("CredentialServiceURL is empty")}
-	}
-	if data.ProtocolServiceURL == "" {
-		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("ProtocolServiceURL is empty")}
+	stsClientID, ok := stsClientIDVal.(string)
+	if !ok || stsClientID == "" {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("'%s' in activity context is not a valid string for orchestration %s", STSClientIDKey, ctx.OID())}
 	}
 
-	// resolve vault client secret for the new participant
+	did := data.ParticipantID
+	if !strings.HasPrefix(did, "did:web:") {
+		p.Monitor.Warnf("Participant identifiers are expected to be Web-DIDs, but this one was not: '%s'. Subsequent communication may be severely impacted!", did)
+	}
+
+	// resolve vault credentials for the control plane config
 	vaultAccessSecret, err := p.VaultClient.ResolveSecret(ctx.Context(), data.VaultAccessClientID)
 	if err != nil {
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error retrieving client secret for orchestration %s: %w", ctx.OID(), err)}
-	}
-	// create participant-context in IdentityHub
-	did := data.ParticipantID
-
-	if !strings.HasPrefix(did, "did:web:") {
-		p.Monitor.Warnf("Participant identifiers are expected to be Web-DIDs, but this one was not: '%s'. Subsequent communication may be severely impacted!", did)
 	}
 
 	vaultCreds := edcv.VaultCredentials{
@@ -147,24 +130,11 @@ func (p EDCVActivityProcessor) handleDeployAction(ctx api.ActivityContext, data 
 		ClientSecret: vaultAccessSecret,
 		TokenURL:     p.TokenURL,
 	}
-
-	_, identyHubSpan := p.tracer.Start(ctx.Context(), "cfm.agent.edcv.deploy.identityhub", trace.WithSpanKind(trace.SpanKindClient))
-
-	manifest := identityhub.NewParticipantManifest(participantContextId, did, data.CredentialServiceURL, data.ProtocolServiceURL, func(m *identityhub.ParticipantManifest) {
-		m.VaultCredentials = vaultCreds
-		m.VaultConfig.VaultURL = p.VaultURL
-		m.VaultConfig.FolderPath = participantContextId + "/identityhub"
-		m.CredentialServiceURL = data.CredentialServiceURL
-		m.ProtocolServiceURL = data.ProtocolServiceURL
-	})
-	createResponse, err := p.IdentityAPIClient.CreateParticipantContext(ctx.Context(), manifest)
-	if err != nil {
-		identyHubSpan.RecordError(err)
-		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("cannot create participant in identity hub: %w", err)}
+	vaultConfig := edcv.VaultConfig{
+		VaultURL:   p.VaultURL,
+		SecretPath: "v1/participants",
+		FolderPath: participantContextId + "/identityhub",
 	}
-	identyHubSpan.End()
-
-	vaultConfig := manifest.VaultConfig
 
 	_, ctrl := p.tracer.Start(ctx.Context(), "cfm.agent.edcv.deploy.controlplane", trace.WithSpanKind(trace.SpanKindClient))
 
@@ -182,7 +152,7 @@ func (p EDCVActivityProcessor) handleDeployAction(ctx api.ActivityContext, data 
 
 	// create participant config in Control Plane
 	alias := participantContextId + "-sts-client-secret"
-	config := controlplane.NewParticipantContextConfig(participantContextId, createResponse.STSClientID, alias, data.ParticipantID, vaultConfig, vaultCreds, p.STSTokenURL)
+	config := controlplane.NewParticipantContextConfig(participantContextId, stsClientID, alias, data.ParticipantID, vaultConfig, vaultCreds, p.STSTokenURL)
 	if err := p.ManagementAPIClient.CreateConfig(ctx.Context(), participantContextId, config); err != nil {
 		ctrl.RecordError(err)
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("cannot create participant config in control plane: %w", err)}
@@ -190,23 +160,16 @@ func (p EDCVActivityProcessor) handleDeployAction(ctx api.ActivityContext, data 
 	ctrl.AddEvent("Created ParticipantContextConfig in Control Plane")
 	ctrl.End()
 	p.Monitor.Infof("EDCV activity for participant '%s' (client ID = %s) completed successfully", data.ParticipantID, data.ApiAccessClientID)
-	if err := p.VaultClient.DeleteSecret(ctx.Context(), data.VaultAccessClientID); err != nil {
-		p.Monitor.Warnf("failed to delete secret '%s': %v", data.VaultAccessClientID, err)
-	}
+
 	return api.ActivityResult{Result: api.ActivityResultComplete}
 }
 
-// handleDisposeAction deletes the participant context in IdentityHub and the control plane
+// handleDisposeAction deletes the participant context and config from the EDC control plane
 func (p EDCVActivityProcessor) handleDisposeAction(ctx context.Context, participantContextID string) api.ActivityResult {
 	var errors []error
-	// delete from IdentityHub
-	err := p.IdentityAPIClient.DeleteParticipantContext(ctx, participantContextID)
-	if err != nil {
-		errors = append(errors, err)
-	}
 
 	// delete config from Control Plane
-	err = p.ManagementAPIClient.DeleteConfig(ctx, participantContextID)
+	err := p.ManagementAPIClient.DeleteConfig(ctx, participantContextID)
 	if err != nil {
 		errors = append(errors, err)
 	}
@@ -216,23 +179,11 @@ func (p EDCVActivityProcessor) handleDisposeAction(ctx context.Context, particip
 	if err != nil {
 		errors = append(errors, err)
 	}
+
 	if len(errors) > 0 {
 		errorStrings := Collect(Map(From(errors), func(err error) string { return err.Error() }))
 		errStr := strings.Join(errorStrings, ", ")
 		p.Monitor.Warnf("one or more errors occurred while rolling back participant context '%s': [%s]", participantContextID, errStr)
-
 	}
 	return api.ActivityResult{Result: api.ActivityResultComplete}
-}
-
-// extractWebDid extracts a WebDID from a given URL. Currently not used, as the participant profile contains an "identifier" which is the DID.
-func (p EDCVActivityProcessor) extractWebDid(url string) (string, error) {
-
-	did := strings.Replace(url, "https", "http", -1)
-	did = strings.Replace(did, "http://", "", -1)
-	did = strings.Replace(did, ":", "%3A", 8)
-	did = strings.ReplaceAll(did, "/", ":")
-	did = "did:web:" + did
-
-	return did, nil
 }

--- a/agent/edcv/activity/activity.go
+++ b/agent/edcv/activity/activity.go
@@ -61,6 +61,7 @@ func NewProcessor(config *Config) *EDCVActivityProcessor {
 		ManagementAPIClient: config.ManagementAPIClient,
 		TokenURL:            config.TokenURL,
 		VaultURL:            config.VaultURL,
+		STSTokenURL:         config.STSTokenURL,
 		tracer:              otel.GetTracerProvider().Tracer("cfm.agent.edcv"),
 	}
 }
@@ -69,8 +70,9 @@ type Config struct {
 	serviceapi.VaultClient
 	system.LogMonitor
 	controlplane.ManagementAPIClient
-	TokenURL string
-	VaultURL string
+	TokenURL    string
+	VaultURL    string
+	STSTokenURL string
 }
 
 func (p EDCVActivityProcessor) ProcessDeploy(ctx api.ActivityContext) api.ActivityResult {

--- a/agent/edcv/activity/activity.go
+++ b/agent/edcv/activity/activity.go
@@ -61,7 +61,6 @@ func NewProcessor(config *Config) *EDCVActivityProcessor {
 		ManagementAPIClient: config.ManagementAPIClient,
 		TokenURL:            config.TokenURL,
 		VaultURL:            config.VaultURL,
-		STSTokenURL:         config.STSTokenURL,
 		tracer:              otel.GetTracerProvider().Tracer("cfm.agent.edcv"),
 	}
 }
@@ -70,9 +69,8 @@ type Config struct {
 	serviceapi.VaultClient
 	system.LogMonitor
 	controlplane.ManagementAPIClient
-	TokenURL    string
-	VaultURL    string
-	STSTokenURL string
+	TokenURL string
+	VaultURL string
 }
 
 func (p EDCVActivityProcessor) ProcessDeploy(ctx api.ActivityContext) api.ActivityResult {
@@ -160,6 +158,11 @@ func (p EDCVActivityProcessor) handleDeployAction(ctx api.ActivityContext, data 
 	ctrl.AddEvent("Created ParticipantContextConfig in Control Plane")
 	ctrl.End()
 	p.Monitor.Infof("EDCV activity for participant '%s' (client ID = %s) completed successfully", data.ParticipantID, data.ApiAccessClientID)
+
+	// delete the vault access secret, since it's no longer needed'
+	if err := p.VaultClient.DeleteSecret(ctx.Context(), data.VaultAccessClientID); err != nil {
+		p.Monitor.Warnf("failed to delete secret '%s': %v", data.VaultAccessClientID, err)
+	}
 
 	return api.ActivityResult{Result: api.ActivityResultComplete}
 }

--- a/agent/edcv/activity/activity_test.go
+++ b/agent/edcv/activity/activity_test.go
@@ -41,6 +41,7 @@ func validConfig(opts ...ConfigOptions) *Config {
 		LogMonitor:          system.NoopMonitor{},
 		TokenURL:            "http://auth.example.com/oauth2/token",
 		VaultURL:            "https://vault.example.com:8200",
+		STSTokenURL:         "test-sts-client-id",
 	}
 	for _, opt := range opts {
 		opt(&c)
@@ -245,6 +246,27 @@ func TestEDCVActivityProcessor_Process_MultipleUnknownFields(t *testing.T) {
 }
 
 func TestEDCVActivityProcessor_Process_MissingVaultEntry(t *testing.T) {
+	invalidConfig := validConfig()
+	invalidConfig.VaultClient = NewMockVaultClient() // does not contain any secrets
+	processor := NewProcessor(invalidConfig)
+
+	ctx := context.Background()
+	outputData := make(map[string]any)
+
+	activity := api.Activity{
+		ID:   "activity-multi",
+		Type: "edcv",
+	}
+
+	activityContext := api.NewActivityContext(ctx, "orch-multi", activity, copyOf(processingData), outputData)
+
+	result := processor.ProcessDeploy(activityContext)
+
+	assert.NotNil(t, result.Error)
+	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
+}
+
+func TestEDCVActivityProcessor_Process_MissingStsClientId(t *testing.T) {
 	invalidConfig := validConfig()
 	invalidConfig.VaultClient = NewMockVaultClient() // does not contain any secrets
 	processor := NewProcessor(invalidConfig)

--- a/agent/edcv/activity/activity_test.go
+++ b/agent/edcv/activity/activity_test.go
@@ -41,7 +41,6 @@ func validConfig(opts ...ConfigOptions) *Config {
 		LogMonitor:          system.NoopMonitor{},
 		TokenURL:            "http://auth.example.com/oauth2/token",
 		VaultURL:            "https://vault.example.com:8200",
-		STSTokenURL:         "test-sts-client-id",
 	}
 	for _, opt := range opts {
 		opt(&c)

--- a/agent/edcv/activity/activity_test.go
+++ b/agent/edcv/activity/activity_test.go
@@ -15,10 +15,8 @@ package activity
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"testing"
 
-	"github.com/eclipse-cfm/cfm/agent/common/identityhub"
 	"github.com/eclipse-cfm/cfm/agent/edcv/controlplane"
 	"github.com/eclipse-cfm/cfm/common/model"
 	"github.com/eclipse-cfm/cfm/common/system"
@@ -30,12 +28,6 @@ import (
 
 type ConfigOptions func(*Config)
 
-func WithIdentityHub(client identityhub.IdentityAPIClient) ConfigOptions {
-	return func(config *Config) {
-		config.IdentityAPIClient = client
-	}
-}
-
 func WithControlPlane(client controlplane.ManagementAPIClient) ConfigOptions {
 	return func(config *Config) {
 		config.ManagementAPIClient = client
@@ -46,8 +38,6 @@ func validConfig(opts ...ConfigOptions) *Config {
 	c := Config{
 		VaultClient:         NewMockVaultClient("client-123", "123"),
 		ManagementAPIClient: MockManagementApiClient{},
-		IdentityAPIClient:   MockIdentityHubClient{},
-		Client:              &http.Client{},
 		LogMonitor:          system.NoopMonitor{},
 		TokenURL:            "http://auth.example.com/oauth2/token",
 		VaultURL:            "https://vault.example.com:8200",
@@ -65,11 +55,11 @@ var processingData = map[string]any{
 	"cfm.participant.credentialservice": "https://example.com/credentialservice",
 	"cfm.participant.protocolservice":   "https://example.com/protocolservice",
 	"publicURL":                         "http://test.example.com:1234/fizz/buzz",
+	STSClientIDKey:                      "test-sts-client-id",
 }
 
 func TestEDCVActivityProcessor_Process_WithValidData(t *testing.T) {
-	ih := MockIdentityHubClient{}
-	processor := NewProcessor(validConfig(WithIdentityHub(ih)))
+	processor := NewProcessor(validConfig())
 
 	ctx := context.Background()
 	outputData := make(map[string]any)
@@ -80,7 +70,7 @@ func TestEDCVActivityProcessor_Process_WithValidData(t *testing.T) {
 		Discriminator: api.DeployDiscriminator,
 	}
 
-	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
+	activityContext := api.NewActivityContext(ctx, "orch-123", activity, copyOf(processingData), outputData)
 
 	result := processor.ProcessDeploy(activityContext)
 
@@ -115,8 +105,8 @@ func TestEDCVActivityProcessor_Process_MissingParticipantID(t *testing.T) {
 func TestEDCVActivityProcessor_Process_MissingClientID(t *testing.T) {
 	processor := NewProcessor(validConfig())
 	ctx := context.Background()
-	processingData := copyOf(processingData)
-	delete(processingData, "clientID.vaultAccess")
+	pd := copyOf(processingData)
+	delete(pd, "clientID.vaultAccess")
 	outputData := make(map[string]any)
 
 	activity := api.Activity{
@@ -125,7 +115,7 @@ func TestEDCVActivityProcessor_Process_MissingClientID(t *testing.T) {
 		Discriminator: api.DeployDiscriminator,
 	}
 
-	activityContext := api.NewActivityContext(ctx, "orchestration-2", activity, processingData, outputData)
+	activityContext := api.NewActivityContext(ctx, "orchestration-2", activity, pd, outputData)
 
 	result := processor.ProcessDeploy(activityContext)
 
@@ -135,50 +125,27 @@ func TestEDCVActivityProcessor_Process_MissingClientID(t *testing.T) {
 	assert.Contains(t, result.Error.Error(), "error processing EDC-V activity")
 }
 
-func TestEDCVActivityProcessor_Process_MissingCredentialServiceUrl(t *testing.T) {
+func TestEDCVActivityProcessor_Process_MissingSTSClientID(t *testing.T) {
 	processor := NewProcessor(validConfig())
 	ctx := context.Background()
-	processingData := copyOf(processingData)
-	delete(processingData, "cfm.participant.credentialservice")
+	pd := copyOf(processingData)
+	delete(pd, STSClientIDKey)
 	outputData := make(map[string]any)
 
 	activity := api.Activity{
-		ID:            "activity-2",
+		ID:            "activity-sts",
 		Type:          "edcv",
 		Discriminator: api.DeployDiscriminator,
 	}
 
-	activityContext := api.NewActivityContext(ctx, "orchestration-2", activity, processingData, outputData)
+	activityContext := api.NewActivityContext(ctx, "orchestration-sts", activity, pd, outputData)
 
 	result := processor.ProcessDeploy(activityContext)
 
 	require.NotNil(t, result)
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
 	assert.NotNil(t, result.Error)
-	assert.Contains(t, result.Error.Error(), "CredentialServiceURL is empty")
-}
-
-func TestEDCVActivityProcessor_Process_MissingProtocolServiceUrl(t *testing.T) {
-	processor := NewProcessor(validConfig())
-	ctx := context.Background()
-	processingData := copyOf(processingData)
-	delete(processingData, "cfm.participant.protocolservice")
-	outputData := make(map[string]any)
-
-	activity := api.Activity{
-		ID:            "activity-2",
-		Type:          "edcv",
-		Discriminator: api.DeployDiscriminator,
-	}
-
-	activityContext := api.NewActivityContext(ctx, "orchestration-2", activity, processingData, outputData)
-
-	result := processor.ProcessDeploy(activityContext)
-
-	require.NotNil(t, result)
-	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
-	assert.NotNil(t, result.Error)
-	assert.Contains(t, result.Error.Error(), "ProtocolServiceURL is empty")
+	assert.Contains(t, result.Error.Error(), STSClientIDKey)
 }
 
 func TestEDCVActivityProcessor_Process_EmptyProcessingData(t *testing.T) {
@@ -253,9 +220,7 @@ func TestEDCVActivityProcessor_Process_OrchestrationIDInError(t *testing.T) {
 }
 
 func TestEDCVActivityProcessor_Process_MultipleUnknownFields(t *testing.T) {
-	ih := MockIdentityHubClient{}
-
-	processor := NewProcessor(validConfig(WithIdentityHub(ih)))
+	processor := NewProcessor(validConfig())
 
 	ctx := context.Background()
 	pd := copyOf(processingData)
@@ -280,15 +245,11 @@ func TestEDCVActivityProcessor_Process_MultipleUnknownFields(t *testing.T) {
 }
 
 func TestEDCVActivityProcessor_Process_MissingVaultEntry(t *testing.T) {
-
-	ih := MockIdentityHubClient{}
-
-	invalidConfig := validConfig(WithIdentityHub(ih))
+	invalidConfig := validConfig()
 	invalidConfig.VaultClient = NewMockVaultClient() // does not contain any secrets
 	processor := NewProcessor(invalidConfig)
 
 	ctx := context.Background()
-
 	outputData := make(map[string]any)
 
 	activity := api.Activity{
@@ -296,32 +257,12 @@ func TestEDCVActivityProcessor_Process_MissingVaultEntry(t *testing.T) {
 		Type: "edcv",
 	}
 
-	activityContext := api.NewActivityContext(ctx, "orch-multi", activity, processingData, outputData)
+	activityContext := api.NewActivityContext(ctx, "orch-multi", activity, copyOf(processingData), outputData)
 
 	result := processor.ProcessDeploy(activityContext)
 
 	assert.NotNil(t, result.Error)
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
-}
-
-func TestEDCVActivityProcessor_Process_IdentityHubFailure(t *testing.T) {
-	ih := MockIdentityHubClient{expectedError: fmt.Errorf("some error")}
-	processor := NewProcessor(validConfig(WithIdentityHub(ih)))
-
-	ctx := context.Background()
-	outputData := make(map[string]any)
-
-	activity := api.Activity{
-		ID:   "test-activity",
-		Type: "edcv",
-	}
-
-	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
-
-	result := processor.ProcessDeploy(activityContext)
-
-	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
-	assert.Error(t, result.Error, "some error")
 }
 
 func TestEDCVActivityProcessor_Process_ManagementAPIFailure(t *testing.T) {
@@ -336,7 +277,7 @@ func TestEDCVActivityProcessor_Process_ManagementAPIFailure(t *testing.T) {
 		Discriminator: api.DeployDiscriminator,
 	}
 
-	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
+	activityContext := api.NewActivityContext(ctx, "orch-123", activity, copyOf(processingData), outputData)
 
 	result := processor.ProcessDeploy(activityContext)
 
@@ -356,7 +297,7 @@ func TestEDCVActivityProcessor_Process_ManagementAPIFailureConfig(t *testing.T) 
 		Discriminator: api.DeployDiscriminator,
 	}
 
-	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
+	activityContext := api.NewActivityContext(ctx, "orch-123", activity, copyOf(processingData), outputData)
 
 	result := processor.ProcessDeploy(activityContext)
 
@@ -365,8 +306,7 @@ func TestEDCVActivityProcessor_Process_ManagementAPIFailureConfig(t *testing.T) 
 }
 
 func TestEDCVActivityProcessor_ProcessDispose(t *testing.T) {
-	ih := MockIdentityHubClient{}
-	processor := NewProcessor(validConfig(WithIdentityHub(ih)))
+	processor := NewProcessor(validConfig())
 
 	ctx := context.Background()
 	outputData := make(map[string]any)
@@ -377,7 +317,7 @@ func TestEDCVActivityProcessor_ProcessDispose(t *testing.T) {
 		Discriminator: api.DisposeDiscriminator,
 	}
 
-	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
+	activityContext := api.NewActivityContext(ctx, "orch-123", activity, copyOf(processingData), outputData)
 
 	result := processor.ProcessDispose(activityContext)
 
@@ -386,8 +326,7 @@ func TestEDCVActivityProcessor_ProcessDispose(t *testing.T) {
 }
 
 func TestEDCVActivityProcessor_ProcessDispose_CtrlPlaneParticipantError(t *testing.T) {
-	ih := MockIdentityHubClient{}
-	processor := NewProcessor(validConfig(WithIdentityHub(ih), WithControlPlane(MockManagementApiClient{
+	processor := NewProcessor(validConfig(WithControlPlane(MockManagementApiClient{
 		expectedParticipantError: fmt.Errorf("some error"),
 	})))
 
@@ -400,7 +339,7 @@ func TestEDCVActivityProcessor_ProcessDispose_CtrlPlaneParticipantError(t *testi
 		Discriminator: api.DisposeDiscriminator,
 	}
 
-	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
+	activityContext := api.NewActivityContext(ctx, "orch-123", activity, copyOf(processingData), outputData)
 
 	result := processor.ProcessDispose(activityContext)
 
@@ -409,8 +348,7 @@ func TestEDCVActivityProcessor_ProcessDispose_CtrlPlaneParticipantError(t *testi
 }
 
 func TestEDCVActivityProcessor_ProcessDispose_CtrlPlaneConfigError(t *testing.T) {
-	ih := MockIdentityHubClient{}
-	processor := NewProcessor(validConfig(WithIdentityHub(ih), WithControlPlane(MockManagementApiClient{
+	processor := NewProcessor(validConfig(WithControlPlane(MockManagementApiClient{
 		expectedConfigError: fmt.Errorf("some error"),
 	})))
 
@@ -423,30 +361,7 @@ func TestEDCVActivityProcessor_ProcessDispose_CtrlPlaneConfigError(t *testing.T)
 		Discriminator: api.DisposeDiscriminator,
 	}
 
-	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
-
-	result := processor.ProcessDispose(activityContext)
-
-	// expect to complete successfully, to unblock subsequent agents
-	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)
-}
-
-func TestEDCVActivityProcessor_ProcessDispose_IdentityHubError(t *testing.T) {
-	ih := MockIdentityHubClient{
-		expectedError: fmt.Errorf("some error"),
-	}
-	processor := NewProcessor(validConfig(WithIdentityHub(ih)))
-
-	ctx := context.Background()
-	outputData := make(map[string]any)
-
-	activity := api.Activity{
-		ID:            "test-activity",
-		Type:          "edcv",
-		Discriminator: api.DisposeDiscriminator,
-	}
-
-	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
+	activityContext := api.NewActivityContext(ctx, "orch-123", activity, copyOf(processingData), outputData)
 
 	result := processor.ProcessDispose(activityContext)
 
@@ -501,36 +416,6 @@ func copyOf(m map[string]any) map[string]any {
 		result[k] = v
 	}
 	return result
-}
-
-type MockIdentityHubClient struct {
-	expectedError       error
-	expectedCredentials []identityhub.VerifiableCredentialResource
-}
-
-func (m MockIdentityHubClient) QueryCredentialByType(ctx context.Context, participantContextID string, credentialType string) ([]identityhub.VerifiableCredentialResource, error) {
-	return m.expectedCredentials, m.expectedError
-}
-
-func (m MockIdentityHubClient) DeleteParticipantContext(ctx context.Context, participantContextID string) error {
-	return m.expectedError
-}
-
-func (m MockIdentityHubClient) GetCredentialRequestState(context.Context, string, string) (string, error) {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (m MockIdentityHubClient) RequestCredentials(context.Context, string, identityhub.CredentialRequest) (string, error) {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (m MockIdentityHubClient) CreateParticipantContext(context.Context, identityhub.ParticipantManifest) (*identityhub.CreateParticipantContextResponse, error) {
-	return &identityhub.CreateParticipantContextResponse{
-		STSClientID:     "test-clientid",
-		STSClientSecret: "test-secret-alias",
-	}, m.expectedError
 }
 
 type MockManagementApiClient struct {

--- a/agent/edcv/launcher/launcher.go
+++ b/agent/edcv/launcher/launcher.go
@@ -28,12 +28,13 @@ import (
 )
 
 const (
-	urlKey             = "vault.url" // duplicate of common/vault/assembly.go
-	ActivityType       = "edcv-activity"
-	clientIDKey        = "keycloak.clientID"
-	clientSecretKey    = "keycloak.clientSecret"
-	tokenURLKey        = "keycloak.tokenUrl"
-	controlPlaneURLKey = "controlplane.url"
+	urlKey               = "vault.url" // duplicate of common/vault/assembly.go
+	ActivityType         = "edcv-activity"
+	clientIDKey          = "keycloak.clientID"
+	clientSecretKey      = "keycloak.clientSecret"
+	tokenURLKey          = "keycloak.tokenUrl"
+	identityHubStsURLKey = "identityhub.sts.url"
+	controlPlaneURLKey   = "controlplane.url"
 )
 
 func LaunchAndWaitSignal(shutdown <-chan struct{}) {
@@ -54,10 +55,11 @@ func LaunchAndWaitSignal(shutdown <-chan struct{}) {
 			clientID := ctx.Config.GetString(clientIDKey)
 			clientSecret := ctx.Config.GetString(clientSecretKey)
 			tokenURL := ctx.Config.GetString(tokenURLKey)
+			ihStsURL := ctx.Config.GetString(identityHubStsURLKey)
 			cpURL := ctx.Config.GetString(controlPlaneURLKey)
 			vaultURL := ctx.Config.GetString(urlKey)
 
-			if err := runtime.CheckRequiredParams(clientIDKey, clientID, clientSecretKey, clientSecret, controlPlaneURLKey, cpURL, tokenURLKey, tokenURL); err != nil {
+			if err := runtime.CheckRequiredParams(clientIDKey, clientID, clientSecretKey, clientSecret, controlPlaneURLKey, cpURL, tokenURLKey, tokenURL, identityHubStsURLKey, ihStsURL); err != nil {
 				panic(err)
 			}
 
@@ -73,6 +75,7 @@ func LaunchAndWaitSignal(shutdown <-chan struct{}) {
 				LogMonitor:  ctx.Monitor,
 				TokenURL:    tokenURL,
 				VaultURL:    vaultURL,
+				STSTokenURL: ihStsURL,
 				ManagementAPIClient: controlplane.HttpManagementAPIClient{
 					BaseURL:       cpURL,
 					TokenProvider: provider,

--- a/agent/edcv/launcher/launcher.go
+++ b/agent/edcv/launcher/launcher.go
@@ -28,13 +28,12 @@ import (
 )
 
 const (
-	urlKey               = "vault.url" // duplicate of common/vault/assembly.go
-	ActivityType         = "edcv-activity"
-	clientIDKey          = "keycloak.clientID"
-	clientSecretKey      = "keycloak.clientSecret"
-	tokenURLKey          = "keycloak.tokenUrl"
-	controlPlaneURLKey   = "controlplane.url"
-	identityHubStsURLKey = "identityhub.sts.url"
+	urlKey             = "vault.url" // duplicate of common/vault/assembly.go
+	ActivityType       = "edcv-activity"
+	clientIDKey        = "keycloak.clientID"
+	clientSecretKey    = "keycloak.clientSecret"
+	tokenURLKey        = "keycloak.tokenUrl"
+	controlPlaneURLKey = "controlplane.url"
 )
 
 func LaunchAndWaitSignal(shutdown <-chan struct{}) {
@@ -57,9 +56,8 @@ func LaunchAndWaitSignal(shutdown <-chan struct{}) {
 			tokenURL := ctx.Config.GetString(tokenURLKey)
 			cpURL := ctx.Config.GetString(controlPlaneURLKey)
 			vaultURL := ctx.Config.GetString(urlKey)
-			ihStsURL := ctx.Config.GetString(identityHubStsURLKey)
 
-			if err := runtime.CheckRequiredParams(clientIDKey, clientID, clientSecretKey, clientSecret, controlPlaneURLKey, cpURL, tokenURLKey, tokenURL, identityHubStsURLKey, ihStsURL); err != nil {
+			if err := runtime.CheckRequiredParams(clientIDKey, clientID, clientSecretKey, clientSecret, controlPlaneURLKey, cpURL, tokenURLKey, tokenURL); err != nil {
 				panic(err)
 			}
 
@@ -75,7 +73,6 @@ func LaunchAndWaitSignal(shutdown <-chan struct{}) {
 				LogMonitor:  ctx.Monitor,
 				TokenURL:    tokenURL,
 				VaultURL:    vaultURL,
-				STSTokenURL: ihStsURL,
 				ManagementAPIClient: controlplane.HttpManagementAPIClient{
 					BaseURL:       cpURL,
 					TokenProvider: provider,

--- a/agent/edcv/types.go
+++ b/agent/edcv/types.go
@@ -14,23 +14,10 @@
 
 package edcv
 
-// VaultConfig defines configuration for accessing a vault, including its URL, secret path, and folder path.
-type VaultConfig struct {
-	// VaultURL the base URL of the vault
-	VaultURL string `json:"vaultUrl"`
-	// SecretPath the path of the mount point of the secret engine
-	SecretPath string `json:"secretPath"`
-	// FolderPath the path of the folder within the secret engine where the participant's manifest will be stored. Note that this will be prefixed with the
-	// participant context ID
-	FolderPath string `json:"folderPath"`
-}
+import commonvault "github.com/eclipse-cfm/cfm/agent/common/vault"
 
-// VaultCredentials defines the credentials which are needed to get a JWT which is used to access a vault
-type VaultCredentials struct {
-	// ClientID client ID of the service account of the IdP which is configured in Vault
-	ClientID string `json:"clientId"`
-	// ClientSecret secret of the service account of the IdP, which is configured in Vault
-	ClientSecret string `json:"clientSecret"`
-	// TokenURL URL of the token endpoint of the IdP which is configured in Vault
-	TokenURL string `json:"tokenUrl"`
-}
+// VaultConfig re-exports the common VaultConfig type.
+type VaultConfig = commonvault.Config
+
+// VaultCredentials re-exports the common VaultCredentials type.
+type VaultCredentials = commonvault.Credentials

--- a/agent/ih/Makefile
+++ b/agent/ih/Makefile
@@ -1,0 +1,48 @@
+.PHONY: build test clean run server
+
+# Binary name
+SERVER_BINARY=ihagent
+
+# Build settings
+BUILD_DIR=bin
+SERVER_PATH=./cmd/server/main.go
+
+DOCKER_TAG=latest
+
+# Environment variables
+export CGO_ENABLED=0
+
+# Install development tools
+install-tools:
+
+# Build the application
+build: build-server
+
+# Build the server
+build-server:
+	go build -o $(BUILD_DIR)/$(SERVER_BINARY) $(SERVER_PATH)
+
+# Run tests
+test:
+	$(TEST_CMD)
+
+# Clean build artifacts
+clean:
+	rm -rf $(BUILD_DIR)
+	go clean
+
+# Run the server in development mode
+dev-server: build-server
+	./$(BUILD_DIR)/$(SERVER_BINARY)
+
+# Run the server in production mode
+server: build-server
+	./$(BUILD_DIR)/$(SERVER_BINARY)
+
+# Build for multiple platforms
+build-all:
+	# Server binaries
+	GOOS=linux GOARCH=amd64 go build -o $(BUILD_DIR)/$(SERVER_BINARY)-linux-amd64 $(SERVER_PATH)
+	GOOS=darwin GOARCH=amd64 go build -o $(BUILD_DIR)/$(SERVER_BINARY)-darwin-amd64 $(SERVER_PATH)
+	GOOS=darwin GOARCH=arm64 go build -o $(BUILD_DIR)/$(SERVER_BINARY)-darwin-arm64 $(SERVER_PATH)
+	GOOS=windows GOARCH=amd64 go build -o $(BUILD_DIR)/$(SERVER_BINARY)-windows-amd64.exe $(SERVER_PATH)

--- a/agent/ih/activity/activity.go
+++ b/agent/ih/activity/activity.go
@@ -1,0 +1,176 @@
+//  Copyright (c) 2025 Metaform Systems, Inc
+//
+//  This program and the accompanying materials are made available under the
+//  terms of the Apache License, Version 2.0 which is available at
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  SPDX-License-Identifier: Apache-2.0
+//
+//  Contributors:
+//       Metaform Systems, Inc. - initial API and implementation
+//
+
+package activity
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	commonvault "github.com/eclipse-cfm/cfm/agent/common/vault"
+	"github.com/eclipse-cfm/cfm/assembly/serviceapi"
+	"github.com/eclipse-cfm/cfm/common/system"
+	"github.com/eclipse-cfm/cfm/pmanager/api"
+
+	"github.com/eclipse-cfm/cfm/agent/common/identityhub"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// STSClientIDKey is the key under which the STS client ID returned by IdentityHub is stored in the
+// activity processing data, so that downstream agents (e.g. the edcv-agent) can read it.
+const STSClientIDKey = "ih.sts.clientId"
+
+type IHActivityProcessor struct {
+	api.BaseActivityProcessor
+	VaultClient       serviceapi.VaultClient
+	HTTPClient        *http.Client
+	Monitor           system.LogMonitor
+	IdentityAPIClient identityhub.IdentityAPIClient
+	TokenURL          string
+	VaultURL          string
+	// CredentialServiceURL optional template for the credential service URL; use %s as placeholder for participantContextID
+	CredentialServiceURL string
+	// ProtocolServiceURL optional template for the protocol service URL; use %s as placeholder for participantContextID
+	ProtocolServiceURL string
+	tracer             trace.Tracer
+}
+
+type ihData struct {
+	ParticipantID        string `json:"cfm.participant.id" validate:"required"`
+	VaultAccessClientID  string `json:"clientID.vaultAccess" validate:"required"`
+	ApiAccessClientID    string `json:"clientID.apiAccess" validate:"required"`
+	CredentialServiceURL string `json:"cfm.participant.credentialservice"`
+	ProtocolServiceURL   string `json:"cfm.participant.protocolservice"`
+}
+
+func NewProcessor(config *Config) *IHActivityProcessor {
+	return &IHActivityProcessor{
+		VaultClient:          config.VaultClient,
+		HTTPClient:           config.Client,
+		Monitor:              config.LogMonitor,
+		IdentityAPIClient:    config.IdentityAPIClient,
+		TokenURL:             config.TokenURL,
+		VaultURL:             config.VaultURL,
+		CredentialServiceURL: config.CredentialServiceURL,
+		ProtocolServiceURL:   config.ProtocolServiceURL,
+		tracer:               otel.GetTracerProvider().Tracer("cfm.agent.identityhub"),
+	}
+}
+
+type Config struct {
+	serviceapi.VaultClient
+	*http.Client
+	system.LogMonitor
+	identityhub.IdentityAPIClient
+	TokenURL             string
+	VaultURL             string
+	CredentialServiceURL string
+	ProtocolServiceURL   string
+}
+
+func (p IHActivityProcessor) ProcessDeploy(ctx api.ActivityContext) api.ActivityResult {
+	_, span := p.tracer.Start(ctx.Context(), "cfm.agent.identityhub.deploy")
+	defer span.End()
+
+	var data ihData
+	if err := ctx.ReadValues(&data); err != nil {
+		span.RecordError(err)
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing IH activity for orchestration %s: %w", ctx.OID(), err)}
+	}
+
+	participantContextId := data.ApiAccessClientID
+	span.SetAttributes(attribute.String("cfm.participantContextId", participantContextId))
+	return p.handleDeployAction(ctx, data, participantContextId)
+}
+
+func (p IHActivityProcessor) ProcessDispose(ctx api.ActivityContext) api.ActivityResult {
+	var data ihData
+	if err := ctx.ReadValues(&data); err != nil {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing IH activity for orchestration %s: %w", ctx.OID(), err)}
+	}
+	return p.handleDisposeAction(ctx.Context(), data.ApiAccessClientID)
+}
+
+// handleDeployAction creates the participant context in IdentityHub and stores the returned STSClientID
+// in the activity context so that downstream agents can use it.
+func (p IHActivityProcessor) handleDeployAction(ctx api.ActivityContext, data ihData, participantContextId string) api.ActivityResult {
+
+	// apply URL templates if configured
+	if p.CredentialServiceURL != "" {
+		data.CredentialServiceURL = fmt.Sprintf(p.CredentialServiceURL, participantContextId)
+	}
+	if p.ProtocolServiceURL != "" {
+		data.ProtocolServiceURL = fmt.Sprintf(p.ProtocolServiceURL, participantContextId)
+	}
+
+	if data.CredentialServiceURL == "" {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("CredentialServiceURL is empty")}
+	}
+	if data.ProtocolServiceURL == "" {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("ProtocolServiceURL is empty")}
+	}
+
+	did := data.ParticipantID
+	if !strings.HasPrefix(did, "did:web:") {
+		p.Monitor.Warnf("Participant identifiers are expected to be Web-DIDs, but this one was not: '%s'. Subsequent communication may be severely impacted!", did)
+	}
+
+	// resolve vault access secret for the new participant
+	vaultAccessSecret, err := p.VaultClient.ResolveSecret(ctx.Context(), data.VaultAccessClientID)
+	if err != nil {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error retrieving client secret for orchestration %s: %w", ctx.OID(), err)}
+	}
+
+	vaultCreds := commonvault.Credentials{
+		ClientID:     data.VaultAccessClientID,
+		ClientSecret: vaultAccessSecret,
+		TokenURL:     p.TokenURL,
+	}
+
+	_, ihSpan := p.tracer.Start(ctx.Context(), "cfm.agent.identityhub.deploy", trace.WithSpanKind(trace.SpanKindClient))
+
+	manifest := identityhub.NewParticipantManifest(participantContextId, did, data.CredentialServiceURL, data.ProtocolServiceURL, func(m *identityhub.ParticipantManifest) {
+		m.VaultCredentials = vaultCreds
+		m.VaultConfig.VaultURL = p.VaultURL
+		m.VaultConfig.FolderPath = participantContextId + "/identityhub"
+	})
+	createResponse, err := p.IdentityAPIClient.CreateParticipantContext(ctx.Context(), manifest)
+	if err != nil {
+		ihSpan.RecordError(err)
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("cannot create participant in IdentityHub: %w", err)}
+	}
+	ihSpan.End()
+
+	// make the STS client ID available to downstream agents
+	ctx.SetValue(STSClientIDKey, createResponse.STSClientID)
+
+	// delete the vault access secret, since it's no longer needed'
+	if err := p.VaultClient.DeleteSecret(ctx.Context(), data.VaultAccessClientID); err != nil {
+		p.Monitor.Warnf("failed to delete secret '%s': %v", data.VaultAccessClientID, err)
+	}
+
+	p.Monitor.Infof("IH activity for participant '%s' (client ID = %s) completed successfully", data.ParticipantID, participantContextId)
+	return api.ActivityResult{Result: api.ActivityResultComplete}
+}
+
+// handleDisposeAction deletes the participant context from IdentityHub
+func (p IHActivityProcessor) handleDisposeAction(ctx context.Context, participantContextID string) api.ActivityResult {
+	err := p.IdentityAPIClient.DeleteParticipantContext(ctx, participantContextID)
+	if err != nil {
+		p.Monitor.Warnf("error deleting participant context '%s' from IdentityHub: %v", participantContextID, err)
+	}
+	return api.ActivityResult{Result: api.ActivityResultComplete}
+}

--- a/agent/ih/activity/activity.go
+++ b/agent/ih/activity/activity.go
@@ -33,7 +33,7 @@ import (
 // activity processing data, so that downstream agents (e.g. the edcv-agent) can read it.
 const STSClientIDKey = "ih.sts.clientId"
 
-type IHActivityProcessor struct {
+type IdentityHubActivityProcessor struct {
 	api.BaseActivityProcessor
 	VaultClient       serviceapi.VaultClient
 	HTTPClient        *http.Client
@@ -56,8 +56,8 @@ type ihData struct {
 	ProtocolServiceURL   string `json:"cfm.participant.protocolservice"`
 }
 
-func NewProcessor(config *Config) *IHActivityProcessor {
-	return &IHActivityProcessor{
+func NewProcessor(config *Config) *IdentityHubActivityProcessor {
+	return &IdentityHubActivityProcessor{
 		VaultClient:          config.VaultClient,
 		HTTPClient:           config.Client,
 		Monitor:              config.LogMonitor,
@@ -81,7 +81,7 @@ type Config struct {
 	ProtocolServiceURL   string
 }
 
-func (p IHActivityProcessor) ProcessDeploy(ctx api.ActivityContext) api.ActivityResult {
+func (p IdentityHubActivityProcessor) ProcessDeploy(ctx api.ActivityContext) api.ActivityResult {
 	_, span := p.tracer.Start(ctx.Context(), "cfm.agent.identityhub.deploy")
 	defer span.End()
 
@@ -96,7 +96,7 @@ func (p IHActivityProcessor) ProcessDeploy(ctx api.ActivityContext) api.Activity
 	return p.handleDeployAction(ctx, data, participantContextId)
 }
 
-func (p IHActivityProcessor) ProcessDispose(ctx api.ActivityContext) api.ActivityResult {
+func (p IdentityHubActivityProcessor) ProcessDispose(ctx api.ActivityContext) api.ActivityResult {
 	var data ihData
 	if err := ctx.ReadValues(&data); err != nil {
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing IH activity for orchestration %s: %w", ctx.OID(), err)}
@@ -106,7 +106,7 @@ func (p IHActivityProcessor) ProcessDispose(ctx api.ActivityContext) api.Activit
 
 // handleDeployAction creates the participant context in IdentityHub and stores the returned STSClientID
 // in the activity context so that downstream agents can use it.
-func (p IHActivityProcessor) handleDeployAction(ctx api.ActivityContext, data ihData, participantContextId string) api.ActivityResult {
+func (p IdentityHubActivityProcessor) handleDeployAction(ctx api.ActivityContext, data ihData, participantContextId string) api.ActivityResult {
 
 	// apply URL templates if configured
 	if p.CredentialServiceURL != "" {
@@ -157,17 +157,12 @@ func (p IHActivityProcessor) handleDeployAction(ctx api.ActivityContext, data ih
 	// make the STS client ID available to downstream agents
 	ctx.SetValue(STSClientIDKey, createResponse.STSClientID)
 
-	// delete the vault access secret, since it's no longer needed'
-	if err := p.VaultClient.DeleteSecret(ctx.Context(), data.VaultAccessClientID); err != nil {
-		p.Monitor.Warnf("failed to delete secret '%s': %v", data.VaultAccessClientID, err)
-	}
-
 	p.Monitor.Infof("IH activity for participant '%s' (client ID = %s) completed successfully", data.ParticipantID, participantContextId)
 	return api.ActivityResult{Result: api.ActivityResultComplete}
 }
 
 // handleDisposeAction deletes the participant context from IdentityHub
-func (p IHActivityProcessor) handleDisposeAction(ctx context.Context, participantContextID string) api.ActivityResult {
+func (p IdentityHubActivityProcessor) handleDisposeAction(ctx context.Context, participantContextID string) api.ActivityResult {
 	err := p.IdentityAPIClient.DeleteParticipantContext(ctx, participantContextID)
 	if err != nil {
 		p.Monitor.Warnf("error deleting participant context '%s' from IdentityHub: %v", participantContextID, err)

--- a/agent/ih/activity/activity_test.go
+++ b/agent/ih/activity/activity_test.go
@@ -1,0 +1,265 @@
+//  Copyright (c) 2025 Metaform Systems, Inc
+//
+//  This program and the accompanying materials are made available under the
+//  terms of the Apache License, Version 2.0 which is available at
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  SPDX-License-Identifier: Apache-2.0
+//
+//  Contributors:
+//       Metaform Systems, Inc. - initial API and implementation
+//
+
+package activity
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/eclipse-cfm/cfm/agent/common/identityhub"
+	"github.com/eclipse-cfm/cfm/common/model"
+	"github.com/eclipse-cfm/cfm/common/system"
+	"github.com/eclipse-cfm/cfm/common/types"
+	"github.com/eclipse-cfm/cfm/pmanager/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type ConfigOption func(*Config)
+
+func WithIdentityHub(client identityhub.IdentityAPIClient) ConfigOption {
+	return func(c *Config) {
+		c.IdentityAPIClient = client
+	}
+}
+
+func validConfig(opts ...ConfigOption) *Config {
+	c := Config{
+		VaultClient:       NewMockVaultClient("client-123", "secret-123"),
+		IdentityAPIClient: MockIdentityHubClient{},
+		Client:            &http.Client{},
+		LogMonitor:        system.NoopMonitor{},
+		TokenURL:          "http://auth.example.com/oauth2/token",
+		VaultURL:          "https://vault.example.com:8200",
+	}
+	for _, opt := range opts {
+		opt(&c)
+	}
+	return &c
+}
+
+var processingData = map[string]any{
+	model.ParticipantIdentifier:         "did:web:participant-abc",
+	"clientID.vaultAccess":              "client-123",
+	"clientID.apiAccess":                "client-456",
+	"cfm.participant.credentialservice": "https://example.com/credentialservice",
+	"cfm.participant.protocolservice":   "https://example.com/protocolservice",
+}
+
+func TestIHActivityProcessor_ProcessDeploy_WithValidData(t *testing.T) {
+	processor := NewProcessor(validConfig())
+
+	activityContext := api.NewActivityContext(context.Background(), "orch-1", api.Activity{
+		ID:            "test-activity",
+		Type:          "ih",
+		Discriminator: api.DeployDiscriminator,
+	}, copyOf(processingData), make(map[string]any))
+
+	result := processor.ProcessDeploy(activityContext)
+
+	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)
+	assert.NoError(t, result.Error)
+
+	// STSClientID must be written back into the context
+	stsClientID, ok := activityContext.Value(STSClientIDKey)
+	require.True(t, ok)
+	assert.Equal(t, "test-sts-clientid", stsClientID)
+}
+
+func TestIHActivityProcessor_ProcessDeploy_MissingParticipantID(t *testing.T) {
+	processor := NewProcessor(validConfig())
+	pd := copyOf(processingData)
+	delete(pd, model.ParticipantIdentifier)
+
+	activityContext := api.NewActivityContext(context.Background(), "orch-2", api.Activity{
+		ID:   "activity-1",
+		Type: "ih",
+	}, pd, make(map[string]any))
+
+	result := processor.ProcessDeploy(activityContext)
+
+	require.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
+	assert.Contains(t, result.Error.Error(), "error processing IH activity")
+}
+
+func TestIHActivityProcessor_ProcessDeploy_MissingCredentialServiceURL(t *testing.T) {
+	processor := NewProcessor(validConfig())
+	pd := copyOf(processingData)
+	delete(pd, "cfm.participant.credentialservice")
+
+	activityContext := api.NewActivityContext(context.Background(), "orch-3", api.Activity{
+		ID:            "activity-2",
+		Type:          "ih",
+		Discriminator: api.DeployDiscriminator,
+	}, pd, make(map[string]any))
+
+	result := processor.ProcessDeploy(activityContext)
+
+	require.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
+	assert.Contains(t, result.Error.Error(), "CredentialServiceURL is empty")
+}
+
+func TestIHActivityProcessor_ProcessDeploy_MissingProtocolServiceURL(t *testing.T) {
+	processor := NewProcessor(validConfig())
+	pd := copyOf(processingData)
+	delete(pd, "cfm.participant.protocolservice")
+
+	activityContext := api.NewActivityContext(context.Background(), "orch-4", api.Activity{
+		ID:            "activity-3",
+		Type:          "ih",
+		Discriminator: api.DeployDiscriminator,
+	}, pd, make(map[string]any))
+
+	result := processor.ProcessDeploy(activityContext)
+
+	require.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
+	assert.Contains(t, result.Error.Error(), "ProtocolServiceURL is empty")
+}
+
+func TestIHActivityProcessor_ProcessDeploy_VaultSecretMissing(t *testing.T) {
+	cfg := validConfig()
+	cfg.VaultClient = NewMockVaultClient() // empty vault
+
+	processor := NewProcessor(cfg)
+
+	activityContext := api.NewActivityContext(context.Background(), "orch-5", api.Activity{
+		ID:            "activity-4",
+		Type:          "ih",
+		Discriminator: api.DeployDiscriminator,
+	}, copyOf(processingData), make(map[string]any))
+
+	result := processor.ProcessDeploy(activityContext)
+
+	require.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
+	assert.Contains(t, result.Error.Error(), "error retrieving client secret")
+}
+
+func TestIHActivityProcessor_ProcessDeploy_IdentityHubFailure(t *testing.T) {
+	processor := NewProcessor(validConfig(WithIdentityHub(MockIdentityHubClient{expectedError: fmt.Errorf("ih unavailable")})))
+
+	activityContext := api.NewActivityContext(context.Background(), "orch-6", api.Activity{
+		ID:            "activity-5",
+		Type:          "ih",
+		Discriminator: api.DeployDiscriminator,
+	}, copyOf(processingData), make(map[string]any))
+
+	result := processor.ProcessDeploy(activityContext)
+
+	require.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
+	assert.ErrorContains(t, result.Error, "ih unavailable")
+}
+
+func TestIHActivityProcessor_ProcessDispose_Success(t *testing.T) {
+	processor := NewProcessor(validConfig())
+
+	activityContext := api.NewActivityContext(context.Background(), "orch-7", api.Activity{
+		ID:            "activity-6",
+		Type:          "ih",
+		Discriminator: api.DisposeDiscriminator,
+	}, copyOf(processingData), make(map[string]any))
+
+	result := processor.ProcessDispose(activityContext)
+
+	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)
+	assert.NoError(t, result.Error)
+}
+
+func TestIHActivityProcessor_ProcessDispose_IdentityHubError(t *testing.T) {
+	processor := NewProcessor(validConfig(WithIdentityHub(MockIdentityHubClient{expectedError: fmt.Errorf("some error")})))
+
+	activityContext := api.NewActivityContext(context.Background(), "orch-8", api.Activity{
+		ID:            "activity-7",
+		Type:          "ih",
+		Discriminator: api.DisposeDiscriminator,
+	}, copyOf(processingData), make(map[string]any))
+
+	result := processor.ProcessDispose(activityContext)
+
+	// errors during dispose are logged as warnings; always returns Complete to unblock subsequent agents
+	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)
+}
+
+// --- mocks ---
+
+type MockVaultClient struct {
+	cache map[string]string
+}
+
+func NewMockVaultClient(secrets ...string) MockVaultClient {
+	cache := make(map[string]string)
+	for i := 0; i+1 < len(secrets); i += 2 {
+		cache[secrets[i]] = secrets[i+1]
+	}
+	return MockVaultClient{cache: cache}
+}
+
+func (m MockVaultClient) ResolveSecret(_ context.Context, path string) (string, error) {
+	if v, ok := m.cache[path]; ok {
+		return v, nil
+	}
+	return "", types.ErrNotFound
+}
+
+func (m MockVaultClient) StoreSecret(_ context.Context, path string, value string) error {
+	m.cache[path] = value
+	return nil
+}
+
+func (m MockVaultClient) DeleteSecret(_ context.Context, path string) error {
+	delete(m.cache, path)
+	return nil
+}
+
+func (m MockVaultClient) Close() error { return nil }
+
+func (m MockVaultClient) Health(_ context.Context) error { return nil }
+
+type MockIdentityHubClient struct {
+	expectedError error
+}
+
+func (m MockIdentityHubClient) CreateParticipantContext(_ context.Context, _ identityhub.ParticipantManifest) (*identityhub.CreateParticipantContextResponse, error) {
+	if m.expectedError != nil {
+		return nil, m.expectedError
+	}
+	return &identityhub.CreateParticipantContextResponse{
+		STSClientID:     "test-sts-clientid",
+		STSClientSecret: "test-sts-secret-alias",
+	}, nil
+}
+
+func (m MockIdentityHubClient) DeleteParticipantContext(_ context.Context, _ string) error {
+	return m.expectedError
+}
+
+func (m MockIdentityHubClient) RequestCredentials(_ context.Context, _ string, _ identityhub.CredentialRequest) (string, error) {
+	panic("not implemented")
+}
+
+func (m MockIdentityHubClient) GetCredentialRequestState(_ context.Context, _ string, _ string) (string, error) {
+	panic("not implemented")
+}
+
+func (m MockIdentityHubClient) QueryCredentialByType(_ context.Context, _ string, _ string) ([]identityhub.VerifiableCredentialResource, error) {
+	panic("not implemented")
+}
+
+func copyOf(m map[string]any) map[string]any {
+	result := make(map[string]any)
+	for k, v := range m {
+		result[k] = v
+	}
+	return result
+}

--- a/agent/ih/cmd/server/main.go
+++ b/agent/ih/cmd/server/main.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2025 Metaform Systems, Inc
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Contributors:
+//
+//	Metaform Systems, Inc. - initial API and implementation
+
+package main
+
+import (
+	"github.com/eclipse-cfm/cfm/agent/ih/launcher"
+	"github.com/eclipse-cfm/cfm/common/runtime"
+)
+
+// The entry point for the IdentityHub agent runtime.
+func main() {
+	launcher.LaunchAndWaitSignal(runtime.CreateSignalShutdownChan())
+}

--- a/agent/ih/launcher/launcher.go
+++ b/agent/ih/launcher/launcher.go
@@ -15,8 +15,8 @@ package launcher
 import (
 	"net/http"
 
-	"github.com/eclipse-cfm/cfm/agent/edcv/activity"
-	"github.com/eclipse-cfm/cfm/agent/edcv/controlplane"
+	"github.com/eclipse-cfm/cfm/agent/common/identityhub"
+	"github.com/eclipse-cfm/cfm/agent/ih/activity"
 	"github.com/eclipse-cfm/cfm/assembly/httpclient"
 	"github.com/eclipse-cfm/cfm/assembly/serviceapi"
 	"github.com/eclipse-cfm/cfm/assembly/vault"
@@ -28,20 +28,21 @@ import (
 )
 
 const (
-	urlKey               = "vault.url" // duplicate of common/vault/assembly.go
-	ActivityType         = "edcv-activity"
-	clientIDKey          = "keycloak.clientID"
-	clientSecretKey      = "keycloak.clientSecret"
-	tokenURLKey          = "keycloak.tokenUrl"
-	controlPlaneURLKey   = "controlplane.url"
-	identityHubStsURLKey = "identityhub.sts.url"
+	ActivityType                       = "identityhub-activity"
+	urlKey                             = "vault.url"
+	clientIDKey                        = "keycloak.clientID"
+	clientSecretKey                    = "keycloak.clientSecret"
+	tokenURLKey                        = "keycloak.tokenUrl"
+	identityHubURLKey                  = "identityhub.url"
+	identityHubCredentialServiceURLKey = "identityhub.cs.url"
+	controlPlaneProtocolURLKey         = "controlplane.protocol.url"
 )
 
 func LaunchAndWaitSignal(shutdown <-chan struct{}) {
 	config := natsagent.LauncherConfig{
-		AgentName:    "EDC-V Agent",
-		ServiceName:  "cfm.agent.edcv",
-		ConfigPrefix: "edcvagent",
+		AgentName:    "IdentityHub Agent",
+		ServiceName:  "cfm.agent.identityhub",
+		ConfigPrefix: "ihagent",
 		ActivityType: ActivityType,
 		AssemblyProvider: func() []system.ServiceAssembly {
 			return []system.ServiceAssembly{
@@ -55,11 +56,12 @@ func LaunchAndWaitSignal(shutdown <-chan struct{}) {
 			clientID := ctx.Config.GetString(clientIDKey)
 			clientSecret := ctx.Config.GetString(clientSecretKey)
 			tokenURL := ctx.Config.GetString(tokenURLKey)
-			cpURL := ctx.Config.GetString(controlPlaneURLKey)
+			ihURL := ctx.Config.GetString(identityHubURLKey)
 			vaultURL := ctx.Config.GetString(urlKey)
-			ihStsURL := ctx.Config.GetString(identityHubStsURLKey)
+			ihCsURL := ctx.Config.GetString(identityHubCredentialServiceURLKey)
+			cpProtocolURL := ctx.Config.GetString(controlPlaneProtocolURLKey)
 
-			if err := runtime.CheckRequiredParams(clientIDKey, clientID, clientSecretKey, clientSecret, controlPlaneURLKey, cpURL, tokenURLKey, tokenURL, identityHubStsURLKey, ihStsURL); err != nil {
+			if err := runtime.CheckRequiredParams(clientIDKey, clientID, clientSecretKey, clientSecret, tokenURLKey, tokenURL, identityHubURLKey, ihURL); err != nil {
 				panic(err)
 			}
 
@@ -70,17 +72,20 @@ func LaunchAndWaitSignal(shutdown <-chan struct{}) {
 					TokenURL:     tokenURL,
 					GrantType:    oauth2.ClientCredentials,
 				}, &httpClient)
+
 			return activity.NewProcessor(&activity.Config{
 				VaultClient: vaultClient,
+				Client:      &httpClient,
 				LogMonitor:  ctx.Monitor,
-				TokenURL:    tokenURL,
-				VaultURL:    vaultURL,
-				STSTokenURL: ihStsURL,
-				ManagementAPIClient: controlplane.HttpManagementAPIClient{
-					BaseURL:       cpURL,
+				IdentityAPIClient: identityhub.HttpIdentityAPIClient{
+					BaseURL:       ihURL,
 					TokenProvider: provider,
 					HttpClient:    &httpClient,
 				},
+				TokenURL:             tokenURL,
+				VaultURL:             vaultURL,
+				CredentialServiceURL: ihCsURL,
+				ProtocolServiceURL:   cpProtocolURL,
 			})
 		},
 	}

--- a/docker/Dockerfile.ihagent.dockerfile
+++ b/docker/Dockerfile.ihagent.dockerfile
@@ -1,0 +1,33 @@
+#  Copyright (c) 2025 Metaform Systems, Inc
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+# Build the agent binary
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -ldflags="-s -w" -o bin/ihagent ./agent/ih/cmd/server/main.go
+
+# Production stage
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=builder /app/bin/ihagent /ihagent
+
+ENTRYPOINT ["/ihagent"]


### PR DESCRIPTION
## Summary

- Splits the IdentityHub participant create/delete out of the `edcv-agent` into a new, independently deployable **IdentityHub agent** (`identityhub-activity`)
- The ih-agent writes the returned `STSClientID` into the shared orchestration context under `ih.sts.clientId`; the edcv-agent reads it from there, so the two agents must be sequenced with `edcv-activity` depending on `identityhub-activity`
- `VaultConfig` / `VaultCredentials` are lifted to `agent/common/vault` to break the previous import of `agent/common/identityhub` → `agent/edcv`
- New Docker image target `ihagent` and Makefile targets (`build`, `build-all`, `test`, `clean`, `docker-build-ihagent`, `docker-clean-ihagent`, `load-into-kind-ihagent`) added alongside the existing edcv-agent ones


🤖 Generated with [Claude Code](https://claude.com/claude-code)