### PR TITLE
fix: remove REJECTED state

### DIFF
--- a/agent/common/identityhub/identityhub.go
+++ b/agent/common/identityhub/identityhub.go
@@ -30,10 +30,9 @@ const (
 )
 
 const (
-	CredentialRequestStateCreated  = "CREATED"
-	CredentialRequestStateIssued   = "ISSUED"
-	CredentialRequestStateRejected = "REJECTED"
-	CredentialRequestStateError    = "ERROR"
+	CredentialRequestStateCreated = "CREATED"
+	CredentialRequestStateIssued  = "ISSUED"
+	CredentialRequestStateError   = "ERROR"
 )
 
 type IdentityAPIClient interface {

--- a/agent/onboarding/activity/activity.go
+++ b/agent/onboarding/activity/activity.go
@@ -131,8 +131,6 @@ func (p OnboardingActivityProcessor) processExistingRequest(ctx api.ActivityCont
 		ctx.SetOutputValue("credentialRequest", credentialRequest.CredentialRequestURL)
 		ctx.SetOutputValue("participantContextId", credentialRequest.ParticipantContextID)
 		return api.ActivityResult{Result: api.ActivityResultComplete}
-	case identityhub.CredentialRequestStateRejected:
-		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("credential request for participant '%s' was rejected", credentialRequest.ParticipantContextID)}
 	case identityhub.CredentialRequestStateError:
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("credential request for participant '%s' failed", credentialRequest.ParticipantContextID)}
 	default:

--- a/agent/onboarding/activity/activity_test.go
+++ b/agent/onboarding/activity/activity_test.go
@@ -210,41 +210,6 @@ func TestOnboardingActivityProcessor_ProcessDeploy_WhenPendingRequestCreated(t *
 	assert.Empty(t, activityContext.OutputValues())
 }
 
-func TestOnboardingActivityProcessor_ProcessDeploy_WhenPendingRequestRejected(t *testing.T) {
-	ih := MockIdentityHubClient{
-		expectedState: identityhub.CredentialRequestStateRejected,
-	}
-	processor := OnboardingActivityProcessor{
-		Monitor:           system.NoopMonitor{},
-		IdentityApiClient: ih,
-	}
-
-	var processingData = map[string]any{
-		"clientID.apiAccess":   "test-participant",
-		"participantContextId": "test-participant",
-		"holderPid":            "test-holder-pid",
-		"credentialRequest":    "https://example.com/credentialservice/request/123",
-	}
-
-	ctx := context.Background()
-	outputData := make(map[string]any)
-
-	activity := api.Activity{
-		ID:            "test-activity",
-		Type:          "edcv",
-		Discriminator: api.DeployDiscriminator,
-	}
-
-	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
-
-	result := processor.ProcessDeploy(activityContext)
-
-	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
-	assert.ErrorContains(t, result.Error, "credential request for participant 'test-participant' was rejected")
-
-	assert.Empty(t, activityContext.OutputValues())
-}
-
 func TestOnboardingActivityProcessor_ProcessDeploy_WhenPendingRequestError(t *testing.T) {
 	ih := MockIdentityHubClient{
 		expectedState: identityhub.CredentialRequestStateError,


### PR DESCRIPTION
this PR removes the `CredentialRequestStateRejected` state because it does not exist in the `HolderCredentialRequest` object.

Closes #99 