### PR TITLE
feat: propagate VPA properties through registration to Issuer Service holder

### DIFF
--- a/agent/common/issuerservice/issuer.go
+++ b/agent/common/issuerservice/issuer.go
@@ -37,7 +37,7 @@ type IssuerCredentialResourceDto struct {
 }
 
 type ApiClient interface {
-	CreateHolder(ctx context.Context, did string, holderID string, name string) error
+	CreateHolder(ctx context.Context, did string, holderID string, name string, properties map[string]any) error
 	DeleteHolder(ctx context.Context, holderID string) error
 	RevokeCredential(ctx context.Context, participantContextID string, credentialID string) error
 	QueryCredentialsByType(ctx context.Context, participantContextID string, credentialType string) ([]IssuerCredentialResourceDto, error)
@@ -133,7 +133,7 @@ func (i HttpApiClient) DeleteHolder(ctx context.Context, holderID string) error 
 	return nil
 }
 
-func (i HttpApiClient) CreateHolder(ctx context.Context, did string, holderID string, name string) error {
+func (i HttpApiClient) CreateHolder(ctx context.Context, did string, holderID string, name string, properties map[string]any) error {
 	accessToken, err := i.TokenProvider.GetToken(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get API access token: %w", err)
@@ -143,6 +143,10 @@ func (i HttpApiClient) CreateHolder(ctx context.Context, did string, holderID st
 		"did":      did,
 		"holderId": holderID,
 		"name":     name,
+	}
+
+	if properties != nil {
+		data["properties"] = properties
 	}
 
 	payload, err := json.Marshal(data)

--- a/agent/common/issuerservice/issuer_test.go
+++ b/agent/common/issuerservice/issuer_test.go
@@ -61,7 +61,7 @@ func TestHttpApiClient_CreateHolder(t *testing.T) {
 		HttpClient:    &http.Client{},
 	}
 
-	err := client.CreateHolder(t.Context(), "did:web:test-participant", "did:web:test-participant", "test holder")
+	err := client.CreateHolder(t.Context(), "did:web:test-participant", "did:web:test-participant", "test holder", nil)
 	require.NoError(t, err)
 }
 
@@ -76,7 +76,7 @@ func TestHttpApiClient_CreateHolder_AuthError(t *testing.T) {
 		HttpClient:    &http.Client{},
 	}
 
-	err := client.CreateHolder(t.Context(), "did:web:test-participant", "did:web:test-participant", "test holder")
+	err := client.CreateHolder(t.Context(), "did:web:test-participant", "did:web:test-participant", "test holder", nil)
 	require.ErrorContains(t, err, "test error")
 }
 
@@ -102,7 +102,7 @@ func TestHttpApiClient_CreateHolder_ApiReturnsError(t *testing.T) {
 		HttpClient:    &http.Client{},
 	}
 
-	err := client.CreateHolder(t.Context(), "did:web:test-participant", "did:web:test-participant", "test holder")
+	err := client.CreateHolder(t.Context(), "did:web:test-participant", "did:web:test-participant", "test holder", nil)
 	require.ErrorContains(t, err, "failed to create Holder")
 }
 

--- a/agent/onboarding/activity/activity_test.go
+++ b/agent/onboarding/activity/activity_test.go
@@ -484,7 +484,7 @@ func (m MockIssuerServiceApiClient) DeleteHolder(ctx context.Context, holderID s
 	panic("implement me")
 }
 
-func (m MockIssuerServiceApiClient) CreateHolder(ctx context.Context, did string, holderID string, name string) error {
+func (m MockIssuerServiceApiClient) CreateHolder(ctx context.Context, did string, holderID string, name string, properties map[string]any) error {
 	return m.expectedError
 }
 

--- a/agent/registration/activity/activity.go
+++ b/agent/registration/activity/activity.go
@@ -60,7 +60,7 @@ func (p RegistrationActivityProcessor) ProcessDeploy(ctx api.ActivityContext) ap
 	}
 
 	holderID := regData.DID
-	properties, err := readVpaData(model.IssuerServiceType, ctx)
+	properties, err := ctx.VpaProperties(model.IssuerServiceType)
 	if err != nil {
 		span.RecordError(err)
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error reading vpa data: %w", err)}
@@ -72,37 +72,6 @@ func (p RegistrationActivityProcessor) ProcessDeploy(ctx api.ActivityContext) ap
 	}
 
 	return api.ActivityResult{Result: api.ActivityResultComplete}
-}
-
-func readVpaData(vpaType model.VPAType, ctx api.ActivityContext) (map[string]any, error) {
-	vpaData, ok := ctx.Value(model.VPAData)
-	if !ok {
-		return nil, fmt.Errorf("error reading %s", model.VPAData)
-	}
-	if vpaData == nil {
-		return nil, fmt.Errorf("vpa data ('%s') not found in activity context", model.VPAData)
-	}
-
-	vpaList, ok := vpaData.([]any)
-	if !ok {
-		return nil, fmt.Errorf("vpa data is not a slice")
-	}
-
-	for _, item := range vpaList {
-		vpaEntry, ok := item.(map[string]any)
-		if !ok {
-			continue
-		}
-		if entryType, exists := vpaEntry["vpaType"]; exists && entryType == vpaType.String() {
-			if properties, ok := vpaEntry["properties"].(map[string]any); ok {
-				return properties, nil
-			}
-			return make(map[string]any), nil
-		}
-		return nil, fmt.Errorf("no vpa entry for type '%s' found", vpaType)
-	}
-
-	return nil, fmt.Errorf("vpa entry with type '%s' not found", vpaType)
 }
 
 func (p RegistrationActivityProcessor) ProcessDispose(ctx api.ActivityContext) api.ActivityResult {

--- a/agent/registration/activity/activity.go
+++ b/agent/registration/activity/activity.go
@@ -28,7 +28,7 @@ type RegistrationActivityProcessor struct {
 	IssuerService issuerservice.ApiClient
 }
 
-type RegistrationData struct {
+type registrationData struct {
 	DID        string `json:"cfm.participant.id" validate:"required"`
 	HolderName string `json:"cfm.participant.holdername"`
 }
@@ -49,17 +49,17 @@ func (p RegistrationActivityProcessor) ProcessDeploy(ctx api.ActivityContext) ap
 	tracer := otel.GetTracerProvider().Tracer("cfm.agent.registration")
 	_, span := tracer.Start(ctx.Context(), "cfm.agent.registration.create-holder", trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
-	var registrationData RegistrationData
-	if err := ctx.ReadValues(&registrationData); err != nil {
+	var regData registrationData
+	if err := ctx.ReadValues(&regData); err != nil {
 		span.RecordError(err)
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing Registration activity for orchestration %s: %w", ctx.OID(), err)}
 	}
-	if registrationData.HolderName == "" {
-		registrationData.HolderName = registrationData.DID
+	if regData.HolderName == "" {
+		regData.HolderName = regData.DID
 	}
 
-	holderID := registrationData.DID
-	if err := p.IssuerService.CreateHolder(ctx.Context(), registrationData.DID, holderID, registrationData.HolderName); err != nil {
+	holderID := regData.DID
+	if err := p.IssuerService.CreateHolder(ctx.Context(), regData.DID, holderID, regData.HolderName); err != nil {
 		span.RecordError(err)
 		// todo: inspect error if it is retryable
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error creating holder in ApiClient: %w", err)}
@@ -69,7 +69,7 @@ func (p RegistrationActivityProcessor) ProcessDeploy(ctx api.ActivityContext) ap
 }
 
 func (p RegistrationActivityProcessor) ProcessDispose(ctx api.ActivityContext) api.ActivityResult {
-	var registrationData RegistrationData
+	var registrationData registrationData
 	if err := ctx.ReadValues(&registrationData); err != nil {
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing Registration activity for orchestration %s: %w", ctx.OID(), err)}
 	}

--- a/agent/registration/activity/activity.go
+++ b/agent/registration/activity/activity.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 
 	"github.com/eclipse-cfm/cfm/agent/common/issuerservice"
+	"github.com/eclipse-cfm/cfm/common/model"
 	"github.com/eclipse-cfm/cfm/common/system"
 	"github.com/eclipse-cfm/cfm/pmanager/api"
 	"go.opentelemetry.io/otel"
@@ -59,13 +60,49 @@ func (p RegistrationActivityProcessor) ProcessDeploy(ctx api.ActivityContext) ap
 	}
 
 	holderID := regData.DID
-	if err := p.IssuerService.CreateHolder(ctx.Context(), regData.DID, holderID, regData.HolderName); err != nil {
+	properties, err := readVpaData(model.IssuerServiceType, ctx)
+	if err != nil {
+		span.RecordError(err)
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error reading vpa data: %w", err)}
+	}
+	if err := p.IssuerService.CreateHolder(ctx.Context(), regData.DID, holderID, regData.HolderName, properties); err != nil {
 		span.RecordError(err)
 		// todo: inspect error if it is retryable
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error creating holder in ApiClient: %w", err)}
 	}
 
 	return api.ActivityResult{Result: api.ActivityResultComplete}
+}
+
+func readVpaData(vpaType model.VPAType, ctx api.ActivityContext) (map[string]any, error) {
+	vpaData, ok := ctx.Value(model.VPAData)
+	if !ok {
+		return nil, fmt.Errorf("error reading %s", model.VPAData)
+	}
+	if vpaData == nil {
+		return nil, fmt.Errorf("vpa data ('%s') not found in activity context", model.VPAData)
+	}
+
+	vpaList, ok := vpaData.([]any)
+	if !ok {
+		return nil, fmt.Errorf("vpa data is not a slice")
+	}
+
+	for _, item := range vpaList {
+		vpaEntry, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if entryType, exists := vpaEntry["vpaType"]; exists && entryType == vpaType.String() {
+			if properties, ok := vpaEntry["properties"].(map[string]any); ok {
+				return properties, nil
+			}
+			return make(map[string]any), nil
+		}
+		return nil, fmt.Errorf("no vpa entry for type '%s' found", vpaType)
+	}
+
+	return nil, fmt.Errorf("vpa entry with type '%s' not found", vpaType)
 }
 
 func (p RegistrationActivityProcessor) ProcessDispose(ctx api.ActivityContext) api.ActivityResult {

--- a/agent/registration/activity/activity_test.go
+++ b/agent/registration/activity/activity_test.go
@@ -42,6 +42,7 @@ func TestRegistrationActivityProcessor_MinimalValidData(t *testing.T) {
 
 	processingData := map[string]any{
 		model.ParticipantIdentifier: "did:web:someparticipant",
+		model.VPAData:               validVpaData(nil),
 	}
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
@@ -73,6 +74,7 @@ func TestRegistrationActivityProcessor_FullValidData(t *testing.T) {
 	processingData := map[string]any{
 		model.ParticipantIdentifier:  "did:web:someparticipant",
 		"cfm.participant.holdername": "some holder",
+		model.VPAData:                validVpaData(nil),
 	}
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
@@ -129,6 +131,7 @@ func TestRegistrationActivityProcessor_IssuerServiceFails(t *testing.T) {
 
 	processingData := map[string]any{
 		model.ParticipantIdentifier: "did:web:someparticipant",
+		model.VPAData:               validVpaData(nil),
 	}
 
 	activityContext := api.NewActivityContext(ctx, "orch-123", activity, processingData, outputData)
@@ -137,6 +140,137 @@ func TestRegistrationActivityProcessor_IssuerServiceFails(t *testing.T) {
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
 	assert.ErrorContains(t, result.Error, "some error")
+}
+
+func TestRegistrationActivityProcessor_VpaDataMissing(t *testing.T) {
+	issuerService := MockIssuerService{}
+	processor := NewProcessor(&Config{
+		LogMonitor:    system.NoopMonitor{},
+		IssuerService: &issuerService,
+	})
+
+	processingData := map[string]any{
+		model.ParticipantIdentifier: "did:web:someparticipant",
+	}
+
+	activityContext := api.NewActivityContext(context.Background(), "orch-123", api.Activity{
+		ID:            "test-activity",
+		Type:          "edcv",
+		Discriminator: api.DeployDiscriminator,
+	}, processingData, make(map[string]any))
+
+	result := processor.ProcessDeploy(activityContext)
+
+	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
+	assert.ErrorContains(t, result.Error, model.VPAData)
+}
+
+func TestRegistrationActivityProcessor_VpaDataEmptySlice(t *testing.T) {
+	issuerService := MockIssuerService{}
+	processor := NewProcessor(&Config{
+		LogMonitor:    system.NoopMonitor{},
+		IssuerService: &issuerService,
+	})
+
+	processingData := map[string]any{
+		model.ParticipantIdentifier: "did:web:someparticipant",
+		model.VPAData:               []any{},
+	}
+
+	activityContext := api.NewActivityContext(context.Background(), "orch-123", api.Activity{
+		ID:            "test-activity",
+		Type:          "edcv",
+		Discriminator: api.DeployDiscriminator,
+	}, processingData, make(map[string]any))
+
+	result := processor.ProcessDeploy(activityContext)
+
+	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
+	assert.ErrorContains(t, result.Error, model.IssuerServiceType.String())
+}
+
+func TestRegistrationActivityProcessor_VpaDataTypeMismatch(t *testing.T) {
+	issuerService := MockIssuerService{}
+	processor := NewProcessor(&Config{
+		LogMonitor:    system.NoopMonitor{},
+		IssuerService: &issuerService,
+	})
+
+	processingData := map[string]any{
+		model.ParticipantIdentifier: "did:web:someparticipant",
+		model.VPAData: []any{
+			map[string]any{
+				"vpaType": model.ConnectorType.String(),
+			},
+		},
+	}
+
+	activityContext := api.NewActivityContext(context.Background(), "orch-123", api.Activity{
+		ID:            "test-activity",
+		Type:          "edcv",
+		Discriminator: api.DeployDiscriminator,
+	}, processingData, make(map[string]any))
+
+	result := processor.ProcessDeploy(activityContext)
+
+	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
+	assert.ErrorContains(t, result.Error, model.IssuerServiceType.String())
+}
+
+func TestRegistrationActivityProcessor_VpaDataPropertiesPassedToIssuerService(t *testing.T) {
+	issuerService := MockIssuerService{}
+	processor := NewProcessor(&Config{
+		LogMonitor:    system.NoopMonitor{},
+		IssuerService: &issuerService,
+	})
+
+	props := map[string]any{"region": "eu-west", "tier": "standard"}
+	processingData := map[string]any{
+		model.ParticipantIdentifier: "did:web:someparticipant",
+		model.VPAData:               validVpaData(props),
+	}
+
+	activityContext := api.NewActivityContext(context.Background(), "orch-123", api.Activity{
+		ID:            "test-activity",
+		Type:          "edcv",
+		Discriminator: api.DeployDiscriminator,
+	}, processingData, make(map[string]any))
+
+	result := processor.ProcessDeploy(activityContext)
+
+	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)
+	assert.NoError(t, result.Error)
+	assert.Equal(t, props, issuerService.recorded.properties)
+	assert.Equal(t, issuerService.recorded.properties, props)
+}
+
+func TestRegistrationActivityProcessor_VpaDataNoProperties(t *testing.T) {
+	issuerService := MockIssuerService{}
+	processor := NewProcessor(&Config{
+		LogMonitor:    system.NoopMonitor{},
+		IssuerService: &issuerService,
+	})
+
+	processingData := map[string]any{
+		model.ParticipantIdentifier: "did:web:someparticipant",
+		model.VPAData: []any{
+			map[string]any{
+				"vpaType": model.IssuerServiceType.String(),
+			},
+		},
+	}
+
+	activityContext := api.NewActivityContext(context.Background(), "orch-123", api.Activity{
+		ID:            "test-activity",
+		Type:          "edcv",
+		Discriminator: api.DeployDiscriminator,
+	}, processingData, make(map[string]any))
+
+	result := processor.ProcessDeploy(activityContext)
+
+	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)
+	assert.NoError(t, result.Error)
+	assert.Empty(t, issuerService.recorded.properties)
 }
 
 func TestRegistrationActivityProcessor_ProcessDispose(t *testing.T) {
@@ -195,10 +329,23 @@ func TestRegistrationActivityProcessor_ProcessDispose_IssuerServiceFails(t *test
 	assert.ErrorContains(t, result.Error, "some error")
 }
 
+// validVpaData returns a VPA data slice with a single issuer service entry.
+// If properties is nil, the entry has no properties field.
+func validVpaData(properties map[string]any) []any {
+	entry := map[string]any{
+		"vpaType": model.IssuerServiceType.String(),
+	}
+	if properties != nil {
+		entry["properties"] = properties
+	}
+	return []any{entry}
+}
+
 type regData struct {
-	did      string
-	holderID string
-	name     string
+	did        string
+	holderID   string
+	name       string
+	properties map[string]any
 }
 
 type MockIssuerService struct {
@@ -218,9 +365,10 @@ func (m *MockIssuerService) RevokeCredential(ctx context.Context, participantCon
 	return nil
 }
 
-func (m *MockIssuerService) CreateHolder(ctx context.Context, did string, holderID string, name string) error {
+func (m *MockIssuerService) CreateHolder(ctx context.Context, did string, holderID string, name string, properties map[string]any) error {
 	m.recorded.did = did
 	m.recorded.holderID = holderID
 	m.recorded.name = name
+	m.recorded.properties = properties
 	return m.expectedError
 }

--- a/common/model/model.go
+++ b/common/model/model.go
@@ -22,6 +22,7 @@ const (
 	ConnectorType         VPAType = "cfm.connector"
 	CredentialServiceType VPAType = "cfm.credentialservice"
 	DataPlaneType         VPAType = "cfm.dataplane"
+	IssuerServiceType     VPAType = "cfm.issuer"
 	ParticipantIdentifier         = "cfm.participant.id"
 
 	VPADeployType  OrchestrationType = "cfm.orchestration.vpa.deploy"

--- a/e2e/e2etests/compensation_test.go
+++ b/e2e/e2etests/compensation_test.go
@@ -134,11 +134,11 @@ func Test_VerifyAutoCompensation(t *testing.T) {
 				t.Logf("VPA %s is in state %s", vpa.ID, vpa.State)
 			}
 		}
-		if disposeCount == 3 {
+		if disposeCount == 4 {
 			break
 		}
 	}
-	require.Equal(t, 3, disposeCount, "Expected 3 VPAs to be disposed")
+	require.Equal(t, 4, disposeCount, "Expected 4 VPAs to be disposed")
 
 	// verify that the compensation orchestration ran
 	assert.True(t, disposed, "Expected dispose orchestration to be run")
@@ -253,9 +253,9 @@ func Test_VerifyAutoCompensation_NoCompensationOrchestration(t *testing.T) {
 				t.Logf("VPA %s is in state %s", vpa.ID, vpa.State)
 			}
 		}
-		if disposeCount == 3 {
+		if disposeCount == 4 {
 			break
 		}
 	}
-	require.Equal(t, 3, disposeCount, "Expected 3 VPAs to be in state error")
+	require.Equal(t, 4, disposeCount, "Expected 4 VPAs to be in state error")
 }

--- a/e2e/e2etests/deployment_test.go
+++ b/e2e/e2etests/deployment_test.go
@@ -92,11 +92,11 @@ func Test_VerifyE2E(t *testing.T) {
 				deployCount++
 			}
 		}
-		if deployCount == 3 {
+		if deployCount == 4 {
 			break
 		}
 	}
-	require.Equal(t, 3, deployCount, "Expected 3 deployments to be active")
+	require.Equal(t, 4, deployCount, "Expected 4 deployments to be active")
 
 	var participantProfiles []api.ParticipantProfile
 	err = client.PostToTManagerWithResponse(
@@ -136,7 +136,7 @@ func Test_VerifyE2E(t *testing.T) {
 		model.Query{Predicate: fmt.Sprintf("correlationId = '%s'", statusProfile.ID)}, &orchestrations)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(orchestrations), "Expected 1 orchestration to be created")
-	assert.Equal(t, papi.OrchestrationStateCompleted, papi.OrchestrationState(orchestrations[0].State))
+	assert.Equal(t, papi.OrchestrationStateCompleted, orchestrations[0].State)
 
 	// Dispose VPAs
 	err = client.DeleteToTManager(fmt.Sprintf("tenants/%s/participant-profiles/%s", tenant.ID, participantProfile.ID))
@@ -151,9 +151,9 @@ func Test_VerifyE2E(t *testing.T) {
 				disposeCount++
 			}
 		}
-		if disposeCount == 3 {
+		if disposeCount == 4 {
 			break
 		}
 	}
-	require.Equal(t, 3, disposeCount, "Expected 3 deployments to be disposed")
+	require.Equal(t, 4, disposeCount, "Expected 4 deployments to be disposed")
 }

--- a/pmanager/api/provision.go
+++ b/pmanager/api/provision.go
@@ -165,6 +165,9 @@ type ActivityContext interface {
 
 	// Context returns the underlying context
 	Context() context.Context
+
+	// VpaProperties returns the properties for the given VPA type from the activity context.
+	VpaProperties(vpaType model.VPAType) (map[string]any, error)
 }
 
 type DefinitionManager interface {
@@ -263,4 +266,35 @@ func (d defaultActivityContext) SetOutputValue(key string, value any) {
 
 func (d defaultActivityContext) OutputValues() map[string]any {
 	return d.outputData
+}
+
+func (d defaultActivityContext) VpaProperties(vpaType model.VPAType) (map[string]any, error) {
+	vpaData, ok := d.processingData[model.VPAData]
+	if !ok {
+		return nil, fmt.Errorf("error reading %s", model.VPAData)
+	}
+	if vpaData == nil {
+		return nil, fmt.Errorf("vpa data ('%s') not found in activity context", model.VPAData)
+	}
+
+	vpaList, ok := vpaData.([]any)
+	if !ok {
+		return nil, fmt.Errorf("vpa data is not a slice")
+	}
+
+	for _, item := range vpaList {
+		vpaEntry, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if entryType, exists := vpaEntry["vpaType"]; exists && entryType == vpaType.String() {
+			if properties, ok := vpaEntry["properties"].(map[string]any); ok {
+				return properties, nil
+			}
+			return make(map[string]any), nil
+		}
+		return nil, fmt.Errorf("no vpa entry for type '%s' found", vpaType)
+	}
+
+	return nil, fmt.Errorf("vpa entry with type '%s' not found", vpaType)
 }

--- a/pmanager/api/provision_test.go
+++ b/pmanager/api/provision_test.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/eclipse-cfm/cfm/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -217,6 +218,94 @@ func getTestActivity() Activity {
 		Type:          "test",
 		Discriminator: DeployDiscriminator,
 	}
+}
+
+const testVpaType model.VPAType = "cfm.test.vpa.type"
+const otherVpaType model.VPAType = "cfm.test.vpa.other"
+
+func TestVpaProperties_MissingKey(t *testing.T) {
+	ctx := NewActivityContext(context.Background(), "orch-1", getTestActivity(), map[string]any{}, map[string]any{})
+
+	_, err := ctx.VpaProperties(testVpaType)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, model.VPAData)
+}
+
+func TestVpaProperties_NilValue(t *testing.T) {
+	processingData := map[string]any{model.VPAData: nil}
+	ctx := NewActivityContext(context.Background(), "orch-1", getTestActivity(), processingData, map[string]any{})
+
+	_, err := ctx.VpaProperties(testVpaType)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, model.VPAData)
+}
+
+func TestVpaProperties_NotASlice(t *testing.T) {
+	processingData := map[string]any{model.VPAData: "not-a-slice"}
+	ctx := NewActivityContext(context.Background(), "orch-1", getTestActivity(), processingData, map[string]any{})
+
+	_, err := ctx.VpaProperties(testVpaType)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "not a slice")
+}
+
+func TestVpaProperties_EmptySlice(t *testing.T) {
+	processingData := map[string]any{model.VPAData: []any{}}
+	ctx := NewActivityContext(context.Background(), "orch-1", getTestActivity(), processingData, map[string]any{})
+
+	_, err := ctx.VpaProperties(testVpaType)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, testVpaType.String())
+}
+
+func TestVpaProperties_NoMatchingType(t *testing.T) {
+	processingData := map[string]any{
+		model.VPAData: []any{
+			map[string]any{"vpaType": otherVpaType.String()},
+		},
+	}
+	ctx := NewActivityContext(context.Background(), "orch-1", getTestActivity(), processingData, map[string]any{})
+
+	_, err := ctx.VpaProperties(testVpaType)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, testVpaType.String())
+}
+
+func TestVpaProperties_MatchingTypeWithProperties(t *testing.T) {
+	props := map[string]any{"region": "eu-west", "tier": "standard"}
+	processingData := map[string]any{
+		model.VPAData: []any{
+			map[string]any{
+				"vpaType":    testVpaType.String(),
+				"properties": props,
+			},
+		},
+	}
+	ctx := NewActivityContext(context.Background(), "orch-1", getTestActivity(), processingData, map[string]any{})
+
+	result, err := ctx.VpaProperties(testVpaType)
+
+	require.NoError(t, err)
+	assert.Equal(t, props, result)
+}
+
+func TestVpaProperties_MatchingTypeWithoutProperties(t *testing.T) {
+	processingData := map[string]any{
+		model.VPAData: []any{
+			map[string]any{"vpaType": testVpaType.String()},
+		},
+	}
+	ctx := NewActivityContext(context.Background(), "orch-1", getTestActivity(), processingData, map[string]any{})
+
+	result, err := ctx.VpaProperties(testVpaType)
+
+	require.NoError(t, err)
+	assert.Empty(t, result)
 }
 
 func TestActivityContext_Delete(t *testing.T) {

--- a/tmanager/core/generation_vpa.go
+++ b/tmanager/core/generation_vpa.go
@@ -47,7 +47,8 @@ func (g participantGenerator) Generate(
 	connector := g.generateVPA(model.ConnectorType, vpaProperties, cell)
 	cService := g.generateVPA(model.CredentialServiceType, vpaProperties, cell)
 	dPlane := g.generateVPA(model.DataPlaneType, vpaProperties, cell)
-	vpas := []api.VirtualParticipantAgent{connector, cService, dPlane}
+	issuer := g.generateVPA(model.IssuerServiceType, vpaProperties, cell)
+	vpas := []api.VirtualParticipantAgent{connector, cService, dPlane, issuer}
 
 	pProfile := &api.ParticipantProfile{
 		Entity: api.Entity{

--- a/tmanager/core/generation_vpa_test.go
+++ b/tmanager/core/generation_vpa_test.go
@@ -98,13 +98,14 @@ func TestParticipantProfileGenerator_Generate(t *testing.T) {
 		assert.Equal(t, dProfileIDs, profile.DataspaceProfileIDs)
 
 		// Validate VPAs
-		assert.Len(t, profile.VPAs, 3)
+		assert.Len(t, profile.VPAs, 4)
 
 		// Extract VPA types and verify they match expected types
 		expectedTypes := []model.VPAType{
 			model.ConnectorType,
 			model.CredentialServiceType,
 			model.DataPlaneType,
+			model.IssuerServiceType,
 		}
 		actualTypes := make([]model.VPAType, len(profile.VPAs))
 		for i, vpa := range profile.VPAs {

--- a/tmanager/core/service_participant.go
+++ b/tmanager/core/service_participant.go
@@ -68,10 +68,7 @@ func (p participantService) QueryProfiles(ctx context.Context, predicate query.P
 	})
 }
 
-func (p participantService) DeployProfile(
-	ctx context.Context,
-	tenantID string,
-	deployment *api.NewParticipantProfileDeployment) (*api.ParticipantProfile, error) {
+func (p participantService) DeployProfile(ctx context.Context, tenantID string, deployment *api.NewParticipantProfileDeployment) (*api.ParticipantProfile, error) {
 
 	// TODO perform property validation against a custom schema
 	return store.Trx[api.ParticipantProfile](p.trxContext).AndReturn(ctx, func(ctx context.Context) (*api.ParticipantProfile, error) {


### PR DESCRIPTION

## Summary

- **`tmanager`**: The `IssuerService` VPA is now generated alongside the existing Connector, CredentialService, and DataPlane VPAs, and its per-type properties (from `NewParticipantProfileDeployment.VPAProperties`) are included in the orchestration manifest payload.
- **`pmanager/api`**: Added `VpaProperties(vpaType model.VPAType) (map[string]any, error)` to the `ActivityContext` interface and implemented it on `defaultActivityContext`. It looks up the VPA data slice from the orchestration's processing data and returns the properties for the requested VPA type.
- **`agent/registration`**: The registration activity now calls `ctx.VpaProperties(model.IssuerServiceType)` to retrieve the issuer-specific properties and passes them to `IssuerService.CreateHolder`, which serialises them into the HTTP request body when non-nil.


Closes #105


🤖 Generated with [Claude Code](https://claude.com/claude-code)