### PR TITLE
fix: increase tolerance for missing VPA data

### DIFF
--- a/agent/registration/activity/activity_test.go
+++ b/agent/registration/activity/activity_test.go
@@ -161,8 +161,8 @@ func TestRegistrationActivityProcessor_VpaDataMissing(t *testing.T) {
 
 	result := processor.ProcessDeploy(activityContext)
 
-	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
-	assert.ErrorContains(t, result.Error, model.VPAData)
+	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)
+	assert.NoError(t, result.Error)
 }
 
 func TestRegistrationActivityProcessor_VpaDataEmptySlice(t *testing.T) {
@@ -185,8 +185,8 @@ func TestRegistrationActivityProcessor_VpaDataEmptySlice(t *testing.T) {
 
 	result := processor.ProcessDeploy(activityContext)
 
-	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
-	assert.ErrorContains(t, result.Error, model.IssuerServiceType.String())
+	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)
+	assert.NoError(t, result.Error)
 }
 
 func TestRegistrationActivityProcessor_VpaDataTypeMismatch(t *testing.T) {
@@ -213,8 +213,8 @@ func TestRegistrationActivityProcessor_VpaDataTypeMismatch(t *testing.T) {
 
 	result := processor.ProcessDeploy(activityContext)
 
-	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
-	assert.ErrorContains(t, result.Error, model.IssuerServiceType.String())
+	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)
+	assert.NoError(t, result.Error)
 }
 
 func TestRegistrationActivityProcessor_VpaDataPropertiesPassedToIssuerService(t *testing.T) {

--- a/pmanager/api/provision.go
+++ b/pmanager/api/provision.go
@@ -268,15 +268,15 @@ func (d defaultActivityContext) OutputValues() map[string]any {
 	return d.outputData
 }
 
+// VpaProperties retrieves the properties for a specific VPA type from the activity context. If the `cfm.vpa.data` object is not present,
+// if it does not contain an entry for the specified VPA type, nil is returned. The contents of the `cfm.vpa.data`.`<vpatype>` entry are
+// returned
+// if the `cfm.vpa.data` object is not a slice, an error is returned
 func (d defaultActivityContext) VpaProperties(vpaType model.VPAType) (map[string]any, error) {
 	vpaData, ok := d.processingData[model.VPAData]
-	if !ok {
-		return nil, fmt.Errorf("error reading %s", model.VPAData)
+	if !ok || vpaData == nil {
+		return nil, nil
 	}
-	if vpaData == nil {
-		return nil, fmt.Errorf("vpa data ('%s') not found in activity context", model.VPAData)
-	}
-
 	vpaList, ok := vpaData.([]any)
 	if !ok {
 		return nil, fmt.Errorf("vpa data is not a slice")
@@ -293,8 +293,8 @@ func (d defaultActivityContext) VpaProperties(vpaType model.VPAType) (map[string
 			}
 			return make(map[string]any), nil
 		}
-		return nil, fmt.Errorf("no vpa entry for type '%s' found", vpaType)
+		return nil, nil
 	}
 
-	return nil, fmt.Errorf("vpa entry with type '%s' not found", vpaType)
+	return nil, nil
 }

--- a/pmanager/api/provision_test.go
+++ b/pmanager/api/provision_test.go
@@ -223,23 +223,32 @@ func getTestActivity() Activity {
 const testVpaType model.VPAType = "cfm.test.vpa.type"
 const otherVpaType model.VPAType = "cfm.test.vpa.other"
 
-func TestVpaProperties_MissingKey(t *testing.T) {
-	ctx := NewActivityContext(context.Background(), "orch-1", getTestActivity(), map[string]any{}, map[string]any{})
+func TestVpaProperties_NoEntryForVpa(t *testing.T) {
+	props := map[string]any{"foo": "bar", "quizz": "quazz"}
+	processingData := map[string]any{
+		model.VPAData: []any{
+			map[string]any{
+				"vpaType":    testVpaType.String(),
+				"properties": props,
+			},
+		},
+	}
+	ctx := NewActivityContext(context.Background(), "orch-1", getTestActivity(), processingData, map[string]any{})
 
-	_, err := ctx.VpaProperties(testVpaType)
+	found, err := ctx.VpaProperties("some-other-type")
 
-	require.Error(t, err)
-	assert.ErrorContains(t, err, model.VPAData)
+	require.NoError(t, err)
+	require.Empty(t, found)
 }
 
 func TestVpaProperties_NilValue(t *testing.T) {
 	processingData := map[string]any{model.VPAData: nil}
 	ctx := NewActivityContext(context.Background(), "orch-1", getTestActivity(), processingData, map[string]any{})
 
-	_, err := ctx.VpaProperties(testVpaType)
+	data, err := ctx.VpaProperties(testVpaType)
 
-	require.Error(t, err)
-	assert.ErrorContains(t, err, model.VPAData)
+	require.NoError(t, err)
+	require.Nil(t, data)
 }
 
 func TestVpaProperties_NotASlice(t *testing.T) {
@@ -256,10 +265,10 @@ func TestVpaProperties_EmptySlice(t *testing.T) {
 	processingData := map[string]any{model.VPAData: []any{}}
 	ctx := NewActivityContext(context.Background(), "orch-1", getTestActivity(), processingData, map[string]any{})
 
-	_, err := ctx.VpaProperties(testVpaType)
+	data, err := ctx.VpaProperties(testVpaType)
 
-	require.Error(t, err)
-	assert.ErrorContains(t, err, testVpaType.String())
+	require.NoError(t, err)
+	require.Empty(t, data)
 }
 
 func TestVpaProperties_NoMatchingType(t *testing.T) {
@@ -270,10 +279,10 @@ func TestVpaProperties_NoMatchingType(t *testing.T) {
 	}
 	ctx := NewActivityContext(context.Background(), "orch-1", getTestActivity(), processingData, map[string]any{})
 
-	_, err := ctx.VpaProperties(testVpaType)
+	data, err := ctx.VpaProperties(testVpaType)
 
-	require.Error(t, err)
-	assert.ErrorContains(t, err, testVpaType.String())
+	require.NoError(t, err)
+	require.Empty(t, data)
 }
 
 func TestVpaProperties_MatchingTypeWithProperties(t *testing.T) {


### PR DESCRIPTION
don't fail if no or no valid VPA data is found, simply move on.
