### PR TITLE
feat: add key rotation endpoint for participant profiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ IH_DIR=agent/ih
 KEYCLOAK_DIR=agent/keycloak
 REG_DIR=agent/registration
 ONBOARDING_DIR=agent/onboarding
+IH_KEYROTATE_DIR=agent/ih-keyrotate
 AGENT_COMMON=agent/common
 KIND_CLUSTER_NAME=edcv
 
@@ -71,6 +72,7 @@ build:
 	$(MAKE) -C $(KEYCLOAK_DIR) build
 	$(MAKE) -C $(REG_DIR) build
 	$(MAKE) -C $(ONBOARDING_DIR) build
+	$(MAKE) -C $(IH_KEYROTATE_DIR) build
 
 build-pmanager:
 	@echo "Building pmanager..."
@@ -89,6 +91,7 @@ build-all:
 	$(MAKE) -C $(KEYCLOAK_DIR) build-all
 	$(MAKE) -C $(REG_DIR) build-all
 	$(MAKE) -C $(ONBOARDING_DIR) build-all
+	$(MAKE) -C $(IH_KEYROTATE_DIR) build-all
 
 #==============================================================================
 # Test Commands - Delegate to Service Makefiles
@@ -107,6 +110,7 @@ test: install-gotestsum
 	$(MAKE) -C $(ONBOARDING_DIR) test
 	$(MAKE) -C $(ASSEMBLY_DIR) test
 	$(MAKE) -C $(AGENT_COMMON) test
+	$(MAKE) -C $(IH_KEYROTATE_DIR) test
 
 test-common:
 	@echo "Testing common..."
@@ -157,6 +161,7 @@ clean:
 	$(MAKE) -C $(IH_DIR) clean
 	$(MAKE) -C $(REG_DIR) clean
 	$(MAKE) -C $(ONBOARDING_DIR) clean
+	$(MAKE) -C $(IH_KEYROTATE_DIR) clean
 
 #==============================================================================
 # Tool Commands - Delegate to Service Makefiles
@@ -187,7 +192,7 @@ generate-docs:
 # Docker Commands - Handled at Top Level
 #==============================================================================
 
-docker-build: docker-build-pmanager docker-build-tmanager docker-build-testagent docker-build-edcvagent docker-build-ihagent docker-build-kcagent docker-build-regagent docker-build-obagent
+docker-build: docker-build-pmanager docker-build-tmanager docker-build-testagent docker-build-edcvagent docker-build-ihagent docker-build-kcagent docker-build-regagent docker-build-obagent docker-build-ihkragent
 
 docker-build-pmanager:
 	@echo "Building pmanager Docker image..."
@@ -221,7 +226,11 @@ docker-build-obagent:
 	@echo "Building Onboarding agent Docker image..."
 	docker buildx build -f docker/Dockerfile.obagent.dockerfile -t $(DOCKER_REGISTRY)obagent:$(DOCKER_TAG) .
 
-docker-clean: docker-clean-pmanager docker-clean-tmanager docker-clean-testagent docker-clean-edcvagent docker-clean-ihagent docker-clean-regagent docker-clean-obagent
+docker-build-ihkragent:
+	@echo "Building IdentityHub Key Rotation agent Docker image..."
+	docker buildx build -f docker/Dockerfile.ihkragent.dockerfile -t $(DOCKER_REGISTRY)ihkragent:$(DOCKER_TAG) .
+
+docker-clean: docker-clean-pmanager docker-clean-tmanager docker-clean-testagent docker-clean-edcvagent docker-clean-ihagent docker-clean-regagent docker-clean-obagent docker-clean-ihkragent
 
 docker-clean-pmanager:
 	docker rmi $(DOCKER_REGISTRY)pmanager:$(DOCKER_TAG) || true
@@ -243,6 +252,9 @@ docker-clean-regagent:
 
 docker-clean-obagent:
 	docker rmi $(DOCKER_REGISTRY)obagent:$(DOCKER_TAG) || true
+
+docker-clean-ihkragent:
+	docker rmi $(DOCKER_REGISTRY)ihkragent:$(DOCKER_TAG) || true
 
 #==============================================================================
 # Load images into KinD Cluster
@@ -268,6 +280,9 @@ load-into-kind-obagent: docker-build-obagent
 
 load-into-kind-regagent: docker-build-regagent
 	kind load docker-image -n $(KIND_CLUSTER_NAME) $(DOCKER_REGISTRY)regagent:$(DOCKER_TAG)
+
+load-into-kind-ihkragent: docker-build-ihkragent
+	kind load docker-image -n $(KIND_CLUSTER_NAME) $(DOCKER_REGISTRY)ihkragent:$(DOCKER_TAG)
 
 # builds and loads all images into KinD cluster. Will require kind to be installed and a kind cluster named KIND_CLUSTER_NAME running.
 load-into-kind: docker-build

--- a/agent/common/identityhub/identityhub.go
+++ b/agent/common/identityhub/identityhub.go
@@ -54,33 +54,39 @@ type HttpIdentityAPIClient struct {
 
 // keyDescriptor is the DTO for requesting the rotation of a key in IdentityHub
 type keyDescriptor struct {
-	KeyID           string            `json:"keyId"`
-	PrivateKeyAlias string            `json:"privateKeyAlias"`
-	IsActive        bool              `json:"isActive"`
+	// KeyID the Key ID of the key to rotate. This is NOT the key pair resource ID of IdentityHub. Typically, this ID
+	// consists of the Web:DID + "#" + a unique identifier
+	KeyID string `json:"keyId"`
+	// PrivateKeyAlias the alias of the private key to rotate. This is the handle under which the private key is stored in the
+	// vault by IdentityHub. Usually, for simplicity, this is identical to KeyID
+	PrivateKeyAlias string `json:"privateKeyAlias"`
+	// IsActive whether the new key should be set to active
+	IsActive bool `json:"isActive"`
+	// GeneratorParams the parameters used to generate the new key. This typically contains an entry for "algorithm" and "curve"
 	GeneratorParams map[string]string `json:"keyGeneratorParams"`
 }
 
-func (a HttpIdentityAPIClient) RotateKey(ctx context.Context, participantContextID string, privateKeyAlias string, keyRotationParams api.KeyRotationRequest) error {
+func (a HttpIdentityAPIClient) RotateKey(ctx context.Context, participantContextID string, keyId string, keyRotationParams api.KeyRotationRequest) error {
 	accessToken, err := a.TokenProvider.GetToken(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get API access token: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/participants/%s/keypairs/%s/rotate", a.BaseURL, participantContextID, keyRotationParams.KeyID)
+	url := fmt.Sprintf("%s/participants/%s/keypairs/%s/rotate", a.BaseURL, participantContextID, keyRotationParams.KeyPairID)
 	body := keyDescriptor{
-		KeyID:           privateKeyAlias,
-		PrivateKeyAlias: privateKeyAlias, // generate a new random alias for the new key version
+		KeyID:           keyId,
+		PrivateKeyAlias: keyId,
 		IsActive:        true,
 		GeneratorParams: map[string]string{
 			"algorithm": keyRotationParams.Algorithm,
 			"curve":     keyRotationParams.Curve,
 		},
 	}
-	jsonbody, err := json.Marshal(body)
+	jsonBody, err := json.Marshal(body)
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonbody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonBody))
 	if err != nil {
 		return err
 	}
@@ -100,7 +106,7 @@ func (a HttpIdentityAPIClient) RotateKey(ctx context.Context, participantContext
 		return nil
 	default:
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("failed to delete participant context on IdentityHub: received status code %d, body: %s", resp.StatusCode, string(body))
+		return fmt.Errorf("failed to start key rotation on IdentityHub: received status code %d, body: %s", resp.StatusCode, string(body))
 	}
 
 	return nil

--- a/agent/common/identityhub/identityhub.go
+++ b/agent/common/identityhub/identityhub.go
@@ -43,7 +43,7 @@ type IdentityAPIClient interface {
 	GetCredentialRequestState(ctx context.Context, participantContextID string, credentialRequestID string) (string, error)
 	QueryCredentialByType(ctx context.Context, participantContextID string, credentialType string) ([]common.VerifiableCredentialResource, error)
 	DeleteParticipantContext(ctx context.Context, participantContextID string) error
-	RotateKey(ctx context.Context, participantContextID string, privateKeyAlias string, keyRotationParams api.KeyRotationRequest) error
+	RotateKey(ctx context.Context, participantContextID string, keyId string, keyRotationParams api.KeyRotationRequest) error
 }
 
 type HttpIdentityAPIClient struct {

--- a/agent/common/identityhub/identityhub.go
+++ b/agent/common/identityhub/identityhub.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/eclipse-cfm/cfm/agent/common"
 	"github.com/eclipse-cfm/cfm/common/token"
+	"github.com/eclipse-cfm/cfm/tmanager/api"
 )
 
 const (
@@ -42,12 +43,67 @@ type IdentityAPIClient interface {
 	GetCredentialRequestState(ctx context.Context, participantContextID string, credentialRequestID string) (string, error)
 	QueryCredentialByType(ctx context.Context, participantContextID string, credentialType string) ([]common.VerifiableCredentialResource, error)
 	DeleteParticipantContext(ctx context.Context, participantContextID string) error
+	RotateKey(ctx context.Context, participantContextID string, privateKeyAlias string, keyRotationParams api.KeyRotationRequest) error
 }
 
 type HttpIdentityAPIClient struct {
 	BaseURL       string
 	TokenProvider token.TokenProvider
 	HttpClient    *http.Client
+}
+
+// keyDescriptor is the DTO for requesting the rotation of a key in IdentityHub
+type keyDescriptor struct {
+	KeyID           string            `json:"keyId"`
+	PrivateKeyAlias string            `json:"privateKeyAlias"`
+	IsActive        bool              `json:"isActive"`
+	GeneratorParams map[string]string `json:"keyGeneratorParams"`
+}
+
+func (a HttpIdentityAPIClient) RotateKey(ctx context.Context, participantContextID string, privateKeyAlias string, keyRotationParams api.KeyRotationRequest) error {
+	accessToken, err := a.TokenProvider.GetToken(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get API access token: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/participants/%s/keypairs/%s/rotate", a.BaseURL, participantContextID, keyRotationParams.KeyID)
+	body := keyDescriptor{
+		KeyID:           privateKeyAlias,
+		PrivateKeyAlias: privateKeyAlias, // generate a new random alias for the new key version
+		IsActive:        true,
+		GeneratorParams: map[string]string{
+			"algorithm": keyRotationParams.Algorithm,
+			"curve":     keyRotationParams.Curve,
+		},
+	}
+	jsonbody, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonbody))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	resp, err := a.HttpClient.Do(req)
+	defer a.closeResponse(resp)
+
+	if err != nil {
+		return err
+	}
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusCreated:
+	case http.StatusAccepted:
+	case http.StatusNoContent:
+		return nil
+	default:
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("failed to delete participant context on IdentityHub: received status code %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
 }
 
 func (a HttpIdentityAPIClient) DeleteParticipantContext(ctx context.Context, participantContextID string) error {

--- a/agent/common/identityhub/identityhub_test.go
+++ b/agent/common/identityhub/identityhub_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/eclipse-cfm/cfm/agent/edcv"
 	"github.com/eclipse-cfm/cfm/common/mocks"
+	"github.com/eclipse-cfm/cfm/tmanager/api"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -166,6 +167,111 @@ func TestHttpIdentityAPIClient_DeleteParticipantContext(t *testing.T) {
 
 	err := client.DeleteParticipantContext(t.Context(), "test-id")
 	require.NoError(t, err)
+}
+
+func TestHttpIdentityAPIClient_RotateKey(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/participants/test-participant/keypairs/test-keypair-id/rotate" && r.Method == http.MethodPost {
+			require.Equal(t, "Bearer token", r.Header.Get("Authorization"))
+			require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+
+			var data map[string]any
+			err = json.Unmarshal(body, &data)
+			require.NoError(t, err)
+
+			require.Equal(t, "did:web:test#key-1", data["keyId"])
+			require.Equal(t, "did:web:test#key-1", data["privateKeyAlias"])
+			require.True(t, data["isActive"].(bool))
+			params := data["keyGeneratorParams"].(map[string]any)
+			require.Equal(t, "EC", params["algorithm"])
+			require.Equal(t, "P-256", params["curve"])
+
+			w.WriteHeader(http.StatusNoContent)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	tp := mocks.NewMockTokenProvider(t)
+	tp.On("GetToken", mock.Anything).Return("token", nil)
+	client := HttpIdentityAPIClient{
+		BaseURL:       server.URL,
+		TokenProvider: tp,
+		HttpClient:    &http.Client{},
+	}
+
+	err := client.RotateKey(t.Context(), "test-participant", "did:web:test#key-1", api.KeyRotationRequest{
+		KeyPairID: "test-keypair-id",
+		Algorithm: "EC",
+		Curve:     "P-256",
+	})
+	require.NoError(t, err)
+}
+
+func TestHttpIdentityAPIClient_RotateKey_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+	tp := mocks.NewMockTokenProvider(t)
+	tp.On("GetToken", mock.Anything).Return("token", nil)
+	client := HttpIdentityAPIClient{
+		BaseURL:       server.URL,
+		TokenProvider: tp,
+		HttpClient:    &http.Client{},
+	}
+
+	err := client.RotateKey(t.Context(), "test-participant", "did:web:test#key-1", api.KeyRotationRequest{
+		KeyPairID: "test-keypair-id",
+		Algorithm: "EC",
+		Curve:     "P-256",
+	})
+	require.ErrorContains(t, err, "404")
+}
+
+func TestHttpIdentityAPIClient_RotateKey_AuthError(t *testing.T) {
+	tp := mocks.NewMockTokenProvider(t)
+	tp.On("GetToken", mock.Anything).Return("", fmt.Errorf("auth error"))
+	client := HttpIdentityAPIClient{
+		BaseURL:       "http://foo.bar",
+		TokenProvider: tp,
+		HttpClient:    &http.Client{},
+	}
+
+	err := client.RotateKey(t.Context(), "test-participant", "did:web:test#key-1", api.KeyRotationRequest{
+		KeyPairID: "test-keypair-id",
+		Algorithm: "EC",
+		Curve:     "P-256",
+	})
+	require.ErrorContains(t, err, "failed to get API access token: auth error")
+}
+
+func TestHttpIdentityAPIClient_RotateKey_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal server error"))
+	}))
+	defer server.Close()
+
+	tp := mocks.NewMockTokenProvider(t)
+	tp.On("GetToken", mock.Anything).Return("token", nil)
+	client := HttpIdentityAPIClient{
+		BaseURL:       server.URL,
+		TokenProvider: tp,
+		HttpClient:    &http.Client{},
+	}
+
+	err := client.RotateKey(t.Context(), "test-participant", "did:web:test#key-1", api.KeyRotationRequest{
+		KeyPairID: "test-keypair-id",
+		Algorithm: "EC",
+		Curve:     "P-256",
+	})
+	require.ErrorContains(t, err, "failed to start key rotation on IdentityHub")
+	require.ErrorContains(t, err, "500")
 }
 
 func TestHttpIdentityAPIClient_DeleteParticipantContext_NotFound(t *testing.T) {

--- a/agent/ih-keyrotate/Makefile
+++ b/agent/ih-keyrotate/Makefile
@@ -1,0 +1,48 @@
+.PHONY: build test clean run server
+
+# Binary name
+SERVER_BINARY=ihkragent
+
+# Build settings
+BUILD_DIR=bin
+SERVER_PATH=./cmd/server/main.go
+
+DOCKER_TAG=latest
+
+# Environment variables
+export CGO_ENABLED=0
+
+# Install development tools
+install-tools:
+
+# Build the application
+build: build-server
+
+# Build the server
+build-server:
+	go build -o $(BUILD_DIR)/$(SERVER_BINARY) $(SERVER_PATH)
+
+# Run tests
+test:
+	$(TEST_CMD)
+
+# Clean build artifacts
+clean:
+	rm -rf $(BUILD_DIR)
+	go clean
+
+# Run the server in development mode
+dev-server: build-server
+	./$(BUILD_DIR)/$(SERVER_BINARY)
+
+# Run the server in production mode
+server: build-server
+	./$(BUILD_DIR)/$(SERVER_BINARY)
+
+# Build for multiple platforms
+build-all:
+	# Server binaries
+	GOOS=linux GOARCH=amd64 go build -o $(BUILD_DIR)/$(SERVER_BINARY)-linux-amd64 $(SERVER_PATH)
+	GOOS=darwin GOARCH=amd64 go build -o $(BUILD_DIR)/$(SERVER_BINARY)-darwin-amd64 $(SERVER_PATH)
+	GOOS=darwin GOARCH=arm64 go build -o $(BUILD_DIR)/$(SERVER_BINARY)-darwin-arm64 $(SERVER_PATH)
+	GOOS=windows GOARCH=amd64 go build -o $(BUILD_DIR)/$(SERVER_BINARY)-windows-amd64.exe $(SERVER_PATH)

--- a/agent/ih-keyrotate/activity/activity.go
+++ b/agent/ih-keyrotate/activity/activity.go
@@ -1,0 +1,68 @@
+//  Copyright (c) 2025 Metaform Systems, Inc
+//
+//  This program and the accompanying materials are made available under the
+//  terms of the Apache License, Version 2.0 which is available at
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  SPDX-License-Identifier: Apache-2.0
+//
+//  Contributors:
+//       Metaform Systems, Inc. - initial API and implementation
+//
+
+package activity
+
+import (
+	"fmt"
+
+	"github.com/eclipse-cfm/cfm/agent/common/identityhub"
+	"github.com/eclipse-cfm/cfm/pmanager/api"
+	tmanager "github.com/eclipse-cfm/cfm/tmanager/api"
+	"github.com/google/uuid"
+)
+
+// keyRotationData contains all relevant data for the key rotation activity and is read off of the ActivityContext
+type keyRotationData struct {
+	ParticipantID        string                      `json:"cfm.participant.id" validate:"required"`
+	RotationParams       tmanager.KeyRotationRequest `json:"cfm.key.rotation.data" validate:"required"`
+	ParticipantContextID string                      `json:"participantContextID" validate:"required"`
+}
+type KeyRotationActivityProcessor struct {
+	api.BaseActivityProcessor
+	IdentityAPIClient identityhub.IdentityAPIClient
+}
+
+type Config struct {
+	IdentityHubURL string
+}
+
+func NewProcessor(ihApiClient identityhub.IdentityAPIClient) *KeyRotationActivityProcessor {
+	return &KeyRotationActivityProcessor{
+		IdentityAPIClient: ihApiClient,
+	}
+}
+
+func (p KeyRotationActivityProcessor) Process(ctx api.ActivityContext) api.ActivityResult {
+	var params keyRotationData
+	err := ctx.ReadValues(&params)
+	if err != nil {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: err}
+	}
+
+	// call the keyrotation API
+	privateKeyAlias := params.ParticipantID + "#" + uuid.NewString()
+	err = p.IdentityAPIClient.RotateKey(ctx.Context(), params.ParticipantContextID, privateKeyAlias, params.RotationParams)
+	if err != nil {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: err}
+	}
+
+	return api.ActivityResult{Result: api.ActivityResultComplete}
+}
+
+func (p KeyRotationActivityProcessor) ProcessDeploy(_ api.ActivityContext) api.ActivityResult {
+	return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("cannot use this agent on deploy")}
+}
+
+func (p KeyRotationActivityProcessor) ProcessDispose(_ api.ActivityContext) api.ActivityResult {
+	return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("cannot use this agent on dispose")}
+}

--- a/agent/ih-keyrotate/activity/activity.go
+++ b/agent/ih-keyrotate/activity/activity.go
@@ -23,9 +23,9 @@ import (
 
 // keyRotationData contains all relevant data for the key rotation activity and is read off of the ActivityContext
 type keyRotationData struct {
-	ParticipantID        string                      `json:"cfm.participant.id" validate:"required"`
-	RotationParams       tmanager.KeyRotationRequest `json:"cfm.key.rotation.data" validate:"required"`
-	ParticipantContextID string                      `json:"participantContextID" validate:"required"`
+	ParticipantIdentifier string                      `json:"cfm.participant.id" validate:"required"`
+	RotationParams        tmanager.KeyRotationRequest `json:"cfm.key.rotation.data" validate:"required"`
+	ParticipantContextID  string                      `json:"participantContextID" validate:"required"`
 }
 type KeyRotationActivityProcessor struct {
 	api.BaseActivityProcessor
@@ -50,8 +50,8 @@ func (p KeyRotationActivityProcessor) Process(ctx api.ActivityContext) api.Activ
 	}
 
 	// call the keyrotation API
-	privateKeyAlias := params.ParticipantID + "#" + uuid.NewString()
-	err = p.IdentityAPIClient.RotateKey(ctx.Context(), params.ParticipantContextID, privateKeyAlias, params.RotationParams)
+	keyId := params.ParticipantIdentifier + "#" + uuid.NewString()
+	err = p.IdentityAPIClient.RotateKey(ctx.Context(), params.ParticipantContextID, keyId, params.RotationParams)
 	if err != nil {
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: err}
 	}

--- a/agent/ih-keyrotate/cmd/server/main.go
+++ b/agent/ih-keyrotate/cmd/server/main.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2025 Metaform Systems, Inc
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Contributors:
+//
+//	Metaform Systems, Inc. - initial API and implementation
+
+package main
+
+import (
+	"github.com/eclipse-cfm/cfm/agent/ih-keyrotate/launcher"
+	"github.com/eclipse-cfm/cfm/common/runtime"
+)
+
+// The entry point for the IdentityHub Key Rotation agent runtime.
+func main() {
+	launcher.LaunchAndWaitSignal(runtime.CreateSignalShutdownChan())
+}

--- a/agent/ih-keyrotate/launcher/launcher.go
+++ b/agent/ih-keyrotate/launcher/launcher.go
@@ -1,0 +1,75 @@
+//  Copyright (c) 2025 Metaform Systems, Inc
+//
+//  This program and the accompanying materials are made available under the
+//  terms of the Apache License, Version 2.0 which is available at
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  SPDX-License-Identifier: Apache-2.0
+//
+//  Contributors:
+//       Metaform Systems, Inc. - initial API and implementation
+//
+
+package launcher
+
+import (
+	"net/http"
+
+	"github.com/eclipse-cfm/cfm/agent/common/identityhub"
+	"github.com/eclipse-cfm/cfm/agent/ih-keyrotate/activity"
+	"github.com/eclipse-cfm/cfm/assembly/httpclient"
+	"github.com/eclipse-cfm/cfm/assembly/serviceapi"
+	"github.com/eclipse-cfm/cfm/common/oauth2"
+	"github.com/eclipse-cfm/cfm/common/runtime"
+	"github.com/eclipse-cfm/cfm/common/system"
+	"github.com/eclipse-cfm/cfm/pmanager/api"
+	"github.com/eclipse-cfm/cfm/pmanager/natsagent"
+)
+
+const (
+	ActivityType      = "ih-keyrotation-activity"
+	identityHubURLKey = "identityhub.url"
+	clientIDKey       = "keycloak.clientID"
+	clientSecretKey   = "keycloak.clientSecret"
+	tokenUrlKey       = "keycloak.tokenUrl"
+)
+
+func LaunchAndWaitSignal(shutdown <-chan struct{}) {
+
+	config := natsagent.LauncherConfig{
+		AgentName:    "IdentityHub Key Rotation Agent",
+		ServiceName:  "cfm.agent.identityhub.keyrotate",
+		ConfigPrefix: "ih-keyrotate",
+		ActivityType: ActivityType,
+		AssemblyProvider: func() []system.ServiceAssembly {
+			return []system.ServiceAssembly{
+				&httpclient.HttpClientServiceAssembly{},
+			}
+		},
+		NewProcessor: func(ctx *natsagent.AgentContext) api.ActivityProcessor {
+			httpClient := ctx.Registry.Resolve(serviceapi.HttpClientKey).(http.Client)
+			ihURL := ctx.Config.GetString(identityHubURLKey)
+			clientID := ctx.Config.GetString(clientIDKey)
+			clientSecret := ctx.Config.GetString(clientSecretKey)
+			tokenUrl := ctx.Config.GetString(tokenUrlKey)
+			if err := runtime.CheckRequiredParams(identityHubURLKey, ihURL, clientIDKey, clientID, clientSecretKey, clientSecret, tokenUrlKey, tokenUrl); err != nil {
+				panic(err)
+			}
+
+			provider := oauth2.NewTokenProvider(
+				oauth2.Oauth2Params{
+					ClientID:     clientID,
+					ClientSecret: clientSecret,
+					TokenURL:     tokenUrl,
+					GrantType:    oauth2.ClientCredentials,
+				}, &httpClient)
+
+			return activity.NewProcessor(identityhub.HttpIdentityAPIClient{
+				BaseURL:       ihURL,
+				TokenProvider: provider,
+				HttpClient:    &httpClient,
+			})
+		},
+	}
+	natsagent.LaunchAgent(shutdown, config)
+}

--- a/agent/ih/activity/activity_test.go
+++ b/agent/ih/activity/activity_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/eclipse-cfm/cfm/common/system"
 	"github.com/eclipse-cfm/cfm/common/types"
 	"github.com/eclipse-cfm/cfm/pmanager/api"
+	tmapi "github.com/eclipse-cfm/cfm/tmanager/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -229,6 +230,11 @@ func (m MockVaultClient) Health(_ context.Context) error { return nil }
 
 type MockIdentityHubClient struct {
 	expectedError error
+}
+
+func (m MockIdentityHubClient) RotateKey(ctx context.Context, participantContextID string, privateKeyAlias string, keyRotationParams tmapi.KeyRotationRequest) error {
+	//TODO implement me
+	panic("implement me")
 }
 
 func (m MockIdentityHubClient) CreateParticipantContext(_ context.Context, _ identityhub.ParticipantManifest) (*identityhub.CreateParticipantContextResponse, error) {

--- a/agent/onboarding/activity/activity_test.go
+++ b/agent/onboarding/activity/activity_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/eclipse-cfm/cfm/agent/common/issuerservice"
 	"github.com/eclipse-cfm/cfm/common/system"
 	"github.com/eclipse-cfm/cfm/pmanager/api"
-	"github.com/eclipse-cfm/cfm/tmanager/api"
+	tmapi "github.com/eclipse-cfm/cfm/tmanager/api"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -449,7 +449,7 @@ type MockIdentityHubClient struct {
 	expectedCredentials []common.VerifiableCredentialResource
 }
 
-func (m MockIdentityHubClient) RotateKey(ctx context.context.Context, participantContextID string, keyRotationParams api.api.KeyRotationRequest) error {
+func (m MockIdentityHubClient) RotateKey(ctx context.Context, participantContextID string, keyId string, keyRotationParams tmapi.KeyRotationRequest) error {
 	//TODO implement me
 	panic("implement me")
 }

--- a/agent/onboarding/activity/activity_test.go
+++ b/agent/onboarding/activity/activity_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/eclipse-cfm/cfm/agent/common/issuerservice"
 	"github.com/eclipse-cfm/cfm/common/system"
 	"github.com/eclipse-cfm/cfm/pmanager/api"
+	"github.com/eclipse-cfm/cfm/tmanager/api"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -446,6 +447,11 @@ type MockIdentityHubClient struct {
 	expectedState       string
 	expectedURL         string
 	expectedCredentials []common.VerifiableCredentialResource
+}
+
+func (m MockIdentityHubClient) RotateKey(ctx context.context.Context, participantContextID string, keyRotationParams api.api.KeyRotationRequest) error {
+	//TODO implement me
+	panic("implement me")
 }
 
 func (m MockIdentityHubClient) QueryCredentialByType(ctx context.Context, participantContextID string, credentialType string) ([]common.VerifiableCredentialResource, error) {

--- a/common/model/model.go
+++ b/common/model/model.go
@@ -27,12 +27,15 @@ const (
 	IssuerServiceType     VPAType = "cfm.issuer"
 	ParticipantIdentifier         = "cfm.participant.id"
 
-	VPADeployType  OrchestrationType = "cfm.orchestration.vpa.deploy"
-	VPADisposeType OrchestrationType = "cfm.orchestration.vpa.dispose"
+	VPADeployType   OrchestrationType = "cfm.orchestration.vpa.deploy"
+	VPADisposeType  OrchestrationType = "cfm.orchestration.vpa.dispose"
+	KeyRotationType OrchestrationType = "cfm.orchestration.key.rotate"
 
 	VPAData        = "cfm.vpa.data"
 	CredentialData = "cfm.vpa.credentials"
 	VPAStateData   = "cfm.vpa.state"
+
+	KeyRotationData = "cfm.key.rotation.data"
 )
 
 var Iso8601DurationPattern = regexp.MustCompile(`^P(?:\d+Y)?(?:\d+M)?(?:\d+W)?(?:\d+D)?(?:T(?:\d+H)?(?:\d+M)?(?:\d+S)?)?$`)
@@ -115,7 +118,7 @@ func initValidator() *validator.Validate {
 
 // DurationISO8601 is an ISO 8601 duration (e.g. "P3M", "P1Y2M3DT4H5M6S").
 type DurationISO8601 struct {
-	raw string
+	Raw string
 }
 
 // NewDuration creates a new DurationISO8601 from a string and panics if the string is not a valid ISO 8601 duration.
@@ -123,11 +126,11 @@ func NewDuration(s string) DurationISO8601 {
 	if !Iso8601DurationPattern.MatchString(s) {
 		panic(fmt.Errorf("invalid ISO 8601 duration: %q", s))
 	}
-	return DurationISO8601{raw: s}
+	return DurationISO8601{Raw: s}
 }
 
 func (d DurationISO8601) String() string {
-	return d.raw
+	return d.Raw
 }
 
 func (d *DurationISO8601) UnmarshalJSON(b []byte) error {
@@ -135,10 +138,10 @@ func (d *DurationISO8601) UnmarshalJSON(b []byte) error {
 	if !Iso8601DurationPattern.MatchString(s) {
 		return fmt.Errorf("invalid ISO 8601 duration: %q", s)
 	}
-	d.raw = s
+	d.Raw = s
 	return nil
 }
 
 func (d DurationISO8601) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + d.raw + `"`), nil
+	return []byte(`"` + d.Raw + `"`), nil
 }

--- a/common/model/model.go
+++ b/common/model/model.go
@@ -13,7 +13,9 @@
 package model
 
 import (
+	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/go-playground/validator/v10"
 )
@@ -33,6 +35,7 @@ const (
 	VPAStateData   = "cfm.vpa.state"
 )
 
+var Iso8601DurationPattern = regexp.MustCompile(`^P(?:\d+Y)?(?:\d+M)?(?:\d+W)?(?:\d+D)?(?:T(?:\d+H)?(?:\d+M)?(?:\d+S)?)?$`)
 var Validator = initValidator()
 
 // OrchestrationManifest represents the configuration details for the execution of an orchestration.
@@ -108,4 +111,34 @@ func initValidator() *validator.Validate {
 		return match
 	})
 	return v
+}
+
+// DurationISO8601 is an ISO 8601 duration (e.g. "P3M", "P1Y2M3DT4H5M6S").
+type DurationISO8601 struct {
+	raw string
+}
+
+// NewDuration creates a new DurationISO8601 from a string and panics if the string is not a valid ISO 8601 duration.
+func NewDuration(s string) DurationISO8601 {
+	if !Iso8601DurationPattern.MatchString(s) {
+		panic(fmt.Errorf("invalid ISO 8601 duration: %q", s))
+	}
+	return DurationISO8601{raw: s}
+}
+
+func (d DurationISO8601) String() string {
+	return d.raw
+}
+
+func (d *DurationISO8601) UnmarshalJSON(b []byte) error {
+	s := strings.Trim(string(b), `"`)
+	if !Iso8601DurationPattern.MatchString(s) {
+		return fmt.Errorf("invalid ISO 8601 duration: %q", s)
+	}
+	d.raw = s
+	return nil
+}
+
+func (d DurationISO8601) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + d.raw + `"`), nil
 }

--- a/docker/Dockerfile.ihkragent.dockerfile
+++ b/docker/Dockerfile.ihkragent.dockerfile
@@ -1,0 +1,33 @@
+#  Copyright (c) 2025 Metaform Systems, Inc
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+# Build the agent binary
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -ldflags="-s -w" -o bin/ihkragent ./agent/ih-keyrotate/cmd/server/main.go
+
+# Production stage
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=builder /app/bin/ihkragent /ihkragent
+
+ENTRYPOINT ["/ihkragent"]

--- a/e2e/e2etests/participant_profile_test.go
+++ b/e2e/e2etests/participant_profile_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/eclipse-cfm/cfm/common/sqlstore"
 	"github.com/eclipse-cfm/cfm/e2e/e2efixtures"
 	"github.com/eclipse-cfm/cfm/tmanager/model/v1alpha1"
+	"github.com/google/uuid"
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/require"
 )
@@ -79,7 +80,48 @@ func Test_ParticipantProfileOperations(t *testing.T) {
 	require.NotNil(t, participantProfile)
 	require.NotNil(t, participantProfile.ID)
 
-	verifyRotateKey(t, client, tenant, participantProfile)
+	t.Run("rotate key  success", func(t *testing.T) {
+		verifyRotateKey(t, client, tenant, participantProfile)
+	})
+	t.Run("rotate key invalid request", func(t *testing.T) {
+		verifyRotateKeyInvalidRequest(t, client, tenant, participantProfile)
+	})
+
+	t.Run("profile not found", func(t *testing.T) {
+		err := client.PostToTManager(fmt.Sprintf("tenants/%s/participant-profiles/%s/rotate-keys", tenant.ID, "invalid-profile-id"), v1alpha1.KeyRotationRequest{
+			KeyID: uuid.NewString(),
+		})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "Not Found")
+	})
+
+	t.Run("tenant does not match", func(t *testing.T) {
+		err := client.PostToTManager(fmt.Sprintf("tenants/%s/participant-profiles/%s/rotate-keys", "invalid-tenant-id", participantProfile.ID), v1alpha1.KeyRotationRequest{
+			KeyID: uuid.NewString(),
+		})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "Bad Request")
+	})
+}
+
+func verifyRotateKeyInvalidRequest(t *testing.T, client *e2efixtures.ApiClient, tenant *v1alpha1.Tenant, profile v1alpha1.ParticipantProfile) {
+	krReq := v1alpha1.KeyRotationRequest{
+		// missing: key-id
+	}
+	jsonData, msErr := json.Marshal(krReq)
+	require.NoError(t, msErr)
+	fmt.Println(string(jsonData))
+	t.Run("missing key-id", func(t *testing.T) {
+		err := client.PostToTManager(fmt.Sprintf("tenants/%s/participant-profiles/%s/rotate-keys", tenant.ID, profile.ID), krReq)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "Bad Request")
+	})
+
+	t.Run("missing payload", func(t *testing.T) {
+		err := client.PostToTManager(fmt.Sprintf("tenants/%s/participant-profiles/%s/rotate-keys", tenant.ID, profile.ID), nil)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "Bad Request")
+	})
 }
 
 func verifyRotateKey(t *testing.T, client *e2efixtures.ApiClient, tenant *v1alpha1.Tenant, profile v1alpha1.ParticipantProfile) {
@@ -91,5 +133,4 @@ func verifyRotateKey(t *testing.T, client *e2efixtures.ApiClient, tenant *v1alph
 	fmt.Println(string(jsonData))
 	err := client.PostToTManager(fmt.Sprintf("tenants/%s/participant-profiles/%s/rotate-keys", tenant.ID, profile.ID), krReq)
 	require.NoError(t, err)
-
 }

--- a/e2e/e2etests/participant_profile_test.go
+++ b/e2e/e2etests/participant_profile_test.go
@@ -89,7 +89,7 @@ func Test_ParticipantProfileOperations(t *testing.T) {
 
 	t.Run("profile not found", func(t *testing.T) {
 		err := client.PostToTManager(fmt.Sprintf("tenants/%s/participant-profiles/%s/rotate-keys", tenant.ID, "invalid-profile-id"), v1alpha1.KeyRotationRequest{
-			KeyID: uuid.NewString(),
+			KeyPairID: uuid.NewString(),
 		})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "Not Found")
@@ -97,7 +97,7 @@ func Test_ParticipantProfileOperations(t *testing.T) {
 
 	t.Run("tenant does not match", func(t *testing.T) {
 		err := client.PostToTManager(fmt.Sprintf("tenants/%s/participant-profiles/%s/rotate-keys", "invalid-tenant-id", participantProfile.ID), v1alpha1.KeyRotationRequest{
-			KeyID: uuid.NewString(),
+			KeyPairID: uuid.NewString(),
 		})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "Bad Request")
@@ -126,7 +126,7 @@ func verifyRotateKeyInvalidRequest(t *testing.T, client *e2efixtures.ApiClient, 
 
 func verifyRotateKey(t *testing.T, client *e2efixtures.ApiClient, tenant *v1alpha1.Tenant, profile v1alpha1.ParticipantProfile) {
 	krReq := v1alpha1.KeyRotationRequest{
-		KeyID: "test-key-id",
+		KeyPairID: "test-key-id",
 	}
 	jsonData, msErr := json.Marshal(krReq)
 	require.NoError(t, msErr)

--- a/e2e/e2etests/participant_profile_test.go
+++ b/e2e/e2etests/participant_profile_test.go
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package e2etests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/eclipse-cfm/cfm/common/natsfixtures"
+	"github.com/eclipse-cfm/cfm/common/sqlstore"
+	"github.com/eclipse-cfm/cfm/e2e/e2efixtures"
+	"github.com/eclipse-cfm/cfm/tmanager/model/v1alpha1"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+)
+
+// this test verifies all operations executed on a participant profile
+
+func Test_ParticipantProfileOperations(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	nt, err := natsfixtures.SetupNatsContainer(ctx, cfmBucket)
+
+	require.NoError(t, err)
+
+	defer natsfixtures.TeardownNatsContainer(ctx, nt)
+	defer cleanup()
+
+	pg, dsn, err := sqlstore.SetupTestContainer(t)
+	require.NoError(t, err)
+	defer pg.Terminate(context.Background())
+
+	client := launchPlatformWithAgent(t, nt.URI, dsn)
+	require.NotNil(t, client)
+
+	waitPManager(t, client)
+	waitTManager(t, client)
+
+	tenant, err := e2efixtures.CreateTenant(client, map[string]any{"label": "rotate-key-test"})
+	require.NoError(t, err)
+
+	cell, err := e2efixtures.CreateCell(client)
+	require.NoError(t, err)
+
+	dataspaceProfile, err := e2efixtures.CreateDataspaceProfile(client)
+	require.NoError(t, err)
+
+	deployment := v1alpha1.NewDataspaceProfileDeployment{
+		ProfileID: dataspaceProfile.ID,
+		CellID:    cell.ID,
+	}
+	err = e2efixtures.DeployDataspaceProfile(deployment, client)
+	require.NoError(t, err)
+
+	newParticipantProfile := v1alpha1.NewParticipantProfileDeployment{
+		CellID:           cell.ID,
+		Identifier:       "did:web:foo.com",
+		ParticipantRoles: map[string][]string{dataspaceProfile.ID: {"test-participant"}},
+	}
+
+	var participantProfile v1alpha1.ParticipantProfile
+	err = client.PostToTManagerWithResponse(fmt.Sprintf("tenants/%s/participant-profiles", tenant.ID), newParticipantProfile, &participantProfile)
+	require.NoError(t, err)
+	require.NotNil(t, participantProfile)
+	require.NotNil(t, participantProfile.ID)
+
+	verifyRotateKey(t, client, tenant, participantProfile)
+}
+
+func verifyRotateKey(t *testing.T, client *e2efixtures.ApiClient, tenant *v1alpha1.Tenant, profile v1alpha1.ParticipantProfile) {
+	krReq := v1alpha1.KeyRotationRequest{
+		KeyID: "test-key-id",
+	}
+	jsonData, msErr := json.Marshal(krReq)
+	require.NoError(t, msErr)
+	fmt.Println(string(jsonData))
+	err := client.PostToTManager(fmt.Sprintf("tenants/%s/participant-profiles/%s/rotate-keys", tenant.ID, profile.ID), krReq)
+	require.NoError(t, err)
+
+}

--- a/e2e/e2etests/participant_profile_test.go
+++ b/e2e/e2etests/participant_profile_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/eclipse-cfm/cfm/common/model"
 	"github.com/eclipse-cfm/cfm/common/natsfixtures"
 	"github.com/eclipse-cfm/cfm/common/sqlstore"
 	"github.com/eclipse-cfm/cfm/e2e/e2efixtures"
@@ -72,6 +73,11 @@ func Test_ParticipantProfileOperations(t *testing.T) {
 		CellID:           cell.ID,
 		Identifier:       "did:web:foo.com",
 		ParticipantRoles: map[string][]string{dataspaceProfile.ID: {"test-participant"}},
+		Properties: map[string]any{
+			model.VPAStateData: map[string]any{
+				"participantContextID": "test-participant-context-id",
+			},
+		},
 	}
 
 	var participantProfile v1alpha1.ParticipantProfile
@@ -80,7 +86,7 @@ func Test_ParticipantProfileOperations(t *testing.T) {
 	require.NotNil(t, participantProfile)
 	require.NotNil(t, participantProfile.ID)
 
-	t.Run("rotate key  success", func(t *testing.T) {
+	t.Run("rotate key success", func(t *testing.T) {
 		verifyRotateKey(t, client, tenant, participantProfile)
 	})
 	t.Run("rotate key invalid request", func(t *testing.T) {

--- a/tmanager/api/service.go
+++ b/tmanager/api/service.go
@@ -47,6 +47,7 @@ type ParticipantProfileService interface {
 	QueryProfilesCount(ctx context.Context, predicate query.Predicate) (int64, error)
 	DeployProfile(ctx context.Context, tenantID string, deployment *NewParticipantProfileDeployment) (*ParticipantProfile, error)
 	DisposeProfile(ctx context.Context, tenantID string, participantID string) error
+	RotateKeys(ctx context.Context, tenantID string, participantID string, rotationRequest *KeyRotationRequest) error
 }
 
 // DataspaceProfileService performs dataspace profile operations.

--- a/tmanager/api/types.go
+++ b/tmanager/api/types.go
@@ -121,6 +121,13 @@ type Cell struct {
 // DeploymentState represents the current state of a deployable entity
 type DeploymentState string
 
+type KeyRotationRequest struct {
+	KeyID       string
+	Algorithm   string
+	Curve       string
+	GracePeriod *model.DurationISO8601
+}
+
 const (
 	DeploymentStateInitial   DeploymentState = "initial"
 	DeploymentStatePending   DeploymentState = "pending"

--- a/tmanager/api/types.go
+++ b/tmanager/api/types.go
@@ -121,8 +121,10 @@ type Cell struct {
 // DeploymentState represents the current state of a deployable entity
 type DeploymentState string
 
+// KeyRotationRequest represents the parameters for rotating a key in the IdentityHub. It includes the key pair ID, algorithm,
+// curve, and an optional grace period for the rotation. This object is intended to be used internally in CFM.
 type KeyRotationRequest struct {
-	KeyID       string
+	KeyPairID   string
 	Algorithm   string
 	Curve       string
 	GracePeriod *model.DurationISO8601

--- a/tmanager/core/service_participant.go
+++ b/tmanager/core/service_participant.go
@@ -135,35 +135,6 @@ func (p participantService) DeployProfile(ctx context.Context, tenantID string, 
 	})
 }
 
-// getFilteredProfiles filters dProfiles based on deployment.DataspaceProfileIDs
-func (p participantService) getFilteredProfiles(
-	ctx context.Context,
-	deployment *api.NewParticipantProfileDeployment) ([]api.DataspaceProfile, error) {
-
-	dProfiles, err := collection.CollectAllDeref(p.dataspaceStore.GetAll(ctx))
-	if err != nil {
-		return nil, err
-	}
-
-	if len(deployment.DataspaceProfileIDs) > 0 {
-		profileIDMap := make(map[string]bool)
-		for _, id := range deployment.DataspaceProfileIDs {
-			profileIDMap[id] = true
-		}
-		filteredProfiles := make([]api.DataspaceProfile, 0)
-		for _, profile := range dProfiles {
-			if profileIDMap[profile.ID] {
-				filteredProfiles = append(filteredProfiles, profile)
-			}
-		}
-		dProfiles = filteredProfiles
-	}
-	if len(dProfiles) == 0 {
-		return nil, fmt.Errorf("no dataspace profiles found")
-	}
-	return dProfiles, nil
-}
-
 func (p participantService) DisposeProfile(ctx context.Context, tenantID string, participantID string) error {
 	return p.trxContext.Execute(ctx, func(c context.Context) error {
 		profile, err := p.participantStore.FindByID(c, participantID)
@@ -228,6 +199,39 @@ func (p participantService) DisposeProfile(ctx context.Context, tenantID string,
 
 		return nil
 	})
+}
+
+func (p participantService) RotateKeys(ctx context.Context, tenantID string, participantID string, rotationRequest *api.KeyRotationRequest) error {
+	return nil
+}
+
+// getFilteredProfiles filters dProfiles based on deployment.DataspaceProfileIDs
+func (p participantService) getFilteredProfiles(
+	ctx context.Context,
+	deployment *api.NewParticipantProfileDeployment) ([]api.DataspaceProfile, error) {
+
+	dProfiles, err := collection.CollectAllDeref(p.dataspaceStore.GetAll(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(deployment.DataspaceProfileIDs) > 0 {
+		profileIDMap := make(map[string]bool)
+		for _, id := range deployment.DataspaceProfileIDs {
+			profileIDMap[id] = true
+		}
+		filteredProfiles := make([]api.DataspaceProfile, 0)
+		for _, profile := range dProfiles {
+			if profileIDMap[profile.ID] {
+				filteredProfiles = append(filteredProfiles, profile)
+			}
+		}
+		dProfiles = filteredProfiles
+	}
+	if len(dProfiles) == 0 {
+		return nil, fmt.Errorf("no dataspace profiles found")
+	}
+	return dProfiles, nil
 }
 
 // executeStoreIterator wraps store iterator operations in a transaction context

--- a/tmanager/core/service_participant.go
+++ b/tmanager/core/service_participant.go
@@ -217,6 +217,9 @@ func (p participantService) RotateKeys(ctx context.Context, tenantID string, par
 		if profile.TenantID != tenantID {
 			return nil, types.ErrInvalidInput
 		}
+		if profile.Error {
+			return nil, fmt.Errorf("participant %s is in error state: %s", participantID, profile.ErrorDetail)
+		}
 
 		// resolve orchestration definition by type "cfm.orchestration.key.rotate"
 		orchestrationManifest := model.OrchestrationManifest{
@@ -225,6 +228,11 @@ func (p participantService) RotateKeys(ctx context.Context, tenantID string, par
 			OrchestrationType: model.KeyRotationType,
 			Payload:           make(map[string]any),
 		}
+		stateData := profile.Properties[model.VPAStateData]
+		if stateData == nil {
+			return nil, fmt.Errorf("participant %s is not deployed. The 'participantContextID' property was not found on vpa.state.data", participantID)
+		}
+		orchestrationManifest.Payload["participantContextID"] = stateData.(map[string]any)["participantContextId"]
 		orchestrationManifest.Payload[model.ParticipantIdentifier] = profile.Identifier
 		orchestrationManifest.Payload[model.KeyRotationData] = rotationRequest
 

--- a/tmanager/core/service_participant.go
+++ b/tmanager/core/service_participant.go
@@ -202,13 +202,43 @@ func (p participantService) DisposeProfile(ctx context.Context, tenantID string,
 }
 
 func (p participantService) RotateKeys(ctx context.Context, tenantID string, participantID string, rotationRequest *api.KeyRotationRequest) error {
-	return nil
+
+	if rotationRequest == nil || rotationRequest.KeyID == "" {
+		return fmt.Errorf("%w: key-ID is required", types.ErrInvalidInput)
+	}
+
+	_, err := store.Trx[api.ParticipantProfile](p.trxContext).AndReturn(ctx, func(ctx context.Context) (*api.ParticipantProfile, error) {
+
+		// check if participant exists
+		profile, err := p.participantStore.FindByID(ctx, participantID)
+		if err != nil {
+			return nil, err
+		}
+		if profile.TenantID != tenantID {
+			return nil, types.ErrInvalidInput
+		}
+
+		// resolve orchestration definition by type "cfm.orchestration.key.rotate"
+		orchestrationManifest := model.OrchestrationManifest{
+			ID:                uuid.New().String(),
+			CorrelationID:     participantID,
+			OrchestrationType: model.KeyRotationType,
+			Payload:           make(map[string]any),
+		}
+		orchestrationManifest.Payload[model.ParticipantIdentifier] = profile.Identifier
+		orchestrationManifest.Payload[model.KeyRotationData] = rotationRequest
+
+		err = p.provisionClient.Send(ctx, orchestrationManifest)
+		if err != nil {
+			return nil, fmt.Errorf("error rotating keys for participant %s: %w", participantID, err)
+		}
+		return profile, nil
+	})
+	return err
 }
 
 // getFilteredProfiles filters dProfiles based on deployment.DataspaceProfileIDs
-func (p participantService) getFilteredProfiles(
-	ctx context.Context,
-	deployment *api.NewParticipantProfileDeployment) ([]api.DataspaceProfile, error) {
+func (p participantService) getFilteredProfiles(ctx context.Context, deployment *api.NewParticipantProfileDeployment) ([]api.DataspaceProfile, error) {
 
 	dProfiles, err := collection.CollectAllDeref(p.dataspaceStore.GetAll(ctx))
 	if err != nil {
@@ -251,9 +281,7 @@ func (p participantService) executeStoreIterator(ctx context.Context, storeOp fu
 	}
 }
 
-func generateCredentialSpecs(
-	participantRoles map[string][]string,
-	dProfiles []api.DataspaceProfile) []model.CredentialSpec {
+func generateCredentialSpecs(participantRoles map[string][]string, dProfiles []api.DataspaceProfile) []model.CredentialSpec {
 
 	credentials := make([]model.CredentialSpec, 0)
 	for _, profile := range dProfiles {

--- a/tmanager/core/service_participant.go
+++ b/tmanager/core/service_participant.go
@@ -203,7 +203,7 @@ func (p participantService) DisposeProfile(ctx context.Context, tenantID string,
 
 func (p participantService) RotateKeys(ctx context.Context, tenantID string, participantID string, rotationRequest *api.KeyRotationRequest) error {
 
-	if rotationRequest == nil || rotationRequest.KeyID == "" {
+	if rotationRequest == nil || rotationRequest.KeyPairID == "" {
 		return fmt.Errorf("%w: key-ID is required", types.ErrInvalidInput)
 	}
 

--- a/tmanager/core/service_participant_test.go
+++ b/tmanager/core/service_participant_test.go
@@ -751,6 +751,9 @@ func TestRotateKeys(t *testing.T) {
 
 	tenantID := "tenant-1"
 	profile := newTestParticipantProfile(tenantID, "participant-1") // Create a participant profile for the tenant
+	profile.Properties[model.VPAStateData] = map[string]any{
+		"participantContextID": "test-participant-context-id",
+	}
 	_, err := service.participantStore.Create(ctx, profile)
 	require.NoError(t, err)
 

--- a/tmanager/core/service_participant_test.go
+++ b/tmanager/core/service_participant_test.go
@@ -755,7 +755,7 @@ func TestRotateKeys(t *testing.T) {
 	require.NoError(t, err)
 
 	rotationRequest := &api.KeyRotationRequest{
-		KeyID:     "test-key-id",
+		KeyPairID: "test-key-id",
 		Algorithm: "EdDSA",
 		Curve:     "ed25519",
 		GracePeriod: &model.DurationISO8601{

--- a/tmanager/core/service_participant_test.go
+++ b/tmanager/core/service_participant_test.go
@@ -745,6 +745,55 @@ func TestGetFilteredProfiles(t *testing.T) {
 	})
 }
 
+func TestRotateKeys(t *testing.T) {
+	ctx := context.Background()
+	service := newTestParticipantService()
+
+	tenantID := "tenant-1"
+	profile := newTestParticipantProfile(tenantID, "participant-1") // Create a participant profile for the tenant
+	_, err := service.participantStore.Create(ctx, profile)
+	require.NoError(t, err)
+
+	rotationRequest := &api.KeyRotationRequest{
+		KeyID:     "test-key-id",
+		Algorithm: "EdDSA",
+		Curve:     "ed25519",
+		GracePeriod: &model.DurationISO8601{
+			Raw: "P3M",
+		}, // 3 months
+	}
+
+	t.Run("rotate keys normally", func(t *testing.T) {
+		mockClient := &mockProvisionClient{}
+		service.provisionClient = mockClient
+		mockClient.On("Send", ctx, mock.MatchedBy(func(manifest model.OrchestrationManifest) bool {
+			return manifest.OrchestrationType == model.KeyRotationType &&
+				manifest.Payload[model.KeyRotationData] == rotationRequest
+		})).Return(nil)
+
+		err = service.RotateKeys(ctx, tenantID, profile.ID, rotationRequest)
+		require.NoError(t, err)
+	})
+
+	t.Run("return error when profile not found", func(t *testing.T) {
+		err = service.RotateKeys(ctx, tenantID, "non-existent-profile", rotationRequest)
+		require.Error(t, err)
+		require.ErrorIs(t, err, types.ErrNotFound)
+	})
+
+	t.Run("return error when rotation request is invalid", func(t *testing.T) {
+		rotationRequest = &api.KeyRotationRequest{
+			// key-id missing
+		}
+
+		err = service.RotateKeys(ctx, tenantID, profile.ID, rotationRequest)
+		require.Error(t, err)
+		require.ErrorIs(t, err, types.ErrInvalidInput)
+		assert.Contains(t, err.Error(), "key-ID is required")
+	})
+
+}
+
 // Helper functions
 
 func newTestParticipantProfile(tenantID string, participantID string) *api.ParticipantProfile {

--- a/tmanager/handler/assembly.go
+++ b/tmanager/handler/assembly.go
@@ -201,6 +201,19 @@ func (h *HandlerServiceAssembly) registerParticipantRoutes(r chi.Router, handler
 				}
 				handler.disposeParticipantProfile(w, req, tenantID, participantID)
 			})
+			r.Route("/rotate-keys", func(r chi.Router) {
+				r.Post("/", func(w http.ResponseWriter, req *http.Request) {
+					tenantID, found := handler.ExtractPathVariable(w, req, "tenantID")
+					if !found {
+						return
+					}
+					participantID, found := handler.ExtractPathVariable(w, req, "participantID")
+					if !found {
+						return
+					}
+					handler.rotateParticipantProfileKeys(w, req, tenantID, participantID)
+				})
+			})
 		})
 	})
 }

--- a/tmanager/handler/handlersv1alpha1.go
+++ b/tmanager/handler/handlersv1alpha1.go
@@ -390,3 +390,13 @@ func (h *TMHandler) deployDataspaceProfile(w http.ResponseWriter, req *http.Requ
 func (h *TMHandler) health(w http.ResponseWriter, _ *http.Request) {
 	h.ResponseOK(w, response{Message: "OK"})
 }
+
+func (h *TMHandler) rotateParticipantProfileKeys(w http.ResponseWriter, req *http.Request, tenantID string, participantProfileID string) {
+	if h.InvalidMethod(w, req, http.MethodPost) {
+		return
+	}
+
+	//todo: implement orchestration creation
+
+	h.Accepted(w)
+}

--- a/tmanager/handler/handlersv1alpha1.go
+++ b/tmanager/handler/handlersv1alpha1.go
@@ -19,6 +19,7 @@ import (
 	"github.com/eclipse-cfm/cfm/common/query"
 	"github.com/eclipse-cfm/cfm/common/store"
 	"github.com/eclipse-cfm/cfm/common/system"
+	"github.com/eclipse-cfm/cfm/common/types"
 	"github.com/eclipse-cfm/cfm/tmanager/api"
 	"github.com/eclipse-cfm/cfm/tmanager/model/v1alpha1"
 	"go.opentelemetry.io/otel"
@@ -397,6 +398,17 @@ func (h *TMHandler) rotateParticipantProfileKeys(w http.ResponseWriter, req *htt
 	}
 
 	//todo: implement orchestration creation
+	var input v1alpha1.KeyRotationRequest
+	if !h.ReadPayload(w, req, &input) {
+		h.HandleError(w, types.ErrInvalidInput)
+		return
+	}
+	transformed := v1alpha1.ToKeyRotationRequest(&input)
+	err := h.participantService.RotateKeys(req.Context(), tenantID, participantProfileID, &transformed)
+	if err != nil {
+		h.HandleError(w, err)
+		return
+	}
 
 	h.Accepted(w)
 }

--- a/tmanager/model/v1alpha1/model.go
+++ b/tmanager/model/v1alpha1/model.go
@@ -13,10 +13,16 @@
 package v1alpha1
 
 import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/eclipse-cfm/cfm/common/model"
 )
+
+var iso8601DurationRe = regexp.MustCompile(`^P(?:\d+Y)?(?:\d+M)?(?:\d+W)?(?:\d+D)?(?:T(?:\d+H)?(?:\d+M)?(?:\d+S)?)?$`)
 
 type Entity struct {
 	ID      string `json:"id" required:"true"`
@@ -118,4 +124,54 @@ type DeployableEntity struct {
 type TenantPropertiesDiff struct {
 	Properties map[string]any `json:"properties"`
 	Removed    []string       `json:"removed"`
+}
+
+// KeyRotationRequest represents a request to rotate a key, with optional parameters for algorithm (default: eddsa), curve (default: ed25519), and
+// grace period (default: P3M, 3 months).
+type KeyRotationRequest struct {
+	KeyID       string          `json:"keyId" required:"true"`
+	Algorithm   string          `json:"algorithm,omitempty"`
+	Curve       string          `json:"curve,omitempty"`
+	GracePeriod DurationISO8601 `json:"gracePeriod,omitempty"`
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface to provide default values
+func (r *KeyRotationRequest) UnmarshalJSON(b []byte) error {
+	r.Algorithm = "eddsa"
+	r.Curve = "ed25519"
+	r.GracePeriod = NewDuration("P3M")
+
+	// use a type alias to break infinite recursion
+	type Alias KeyRotationRequest
+	return json.Unmarshal(b, (*Alias)(r))
+}
+
+// DurationISO8601 is an ISO 8601 duration (e.g. "P3M", "P1Y2M3DT4H5M6S").
+type DurationISO8601 struct {
+	raw string
+}
+
+// NewDuration creates a new DurationISO8601 from a string and panics if the string is not a valid ISO 8601 duration.
+func NewDuration(s string) DurationISO8601 {
+	if !iso8601DurationRe.MatchString(s) {
+		panic(fmt.Errorf("invalid ISO 8601 duration: %q", s))
+	}
+	return DurationISO8601{raw: s}
+}
+
+func (d *DurationISO8601) String() string {
+	return d.raw
+}
+
+func (d *DurationISO8601) UnmarshalJSON(b []byte) error {
+	s := strings.Trim(string(b), `"`)
+	if !iso8601DurationRe.MatchString(s) {
+		return fmt.Errorf("invalid ISO 8601 duration: %q", s)
+	}
+	d.raw = s
+	return nil
+}
+
+func (d *DurationISO8601) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + d.raw + `"`), nil
 }

--- a/tmanager/model/v1alpha1/model.go
+++ b/tmanager/model/v1alpha1/model.go
@@ -14,15 +14,10 @@ package v1alpha1
 
 import (
 	"encoding/json"
-	"fmt"
-	"regexp"
-	"strings"
 	"time"
 
-	"github.com/eclipse-cfm/cfm/common/model"
+	common "github.com/eclipse-cfm/cfm/common/model"
 )
-
-var iso8601DurationRe = regexp.MustCompile(`^P(?:\d+Y)?(?:\d+M)?(?:\d+W)?(?:\d+D)?(?:T(?:\d+H)?(?:\d+M)?(?:\d+S)?)?$`)
 
 type Entity struct {
 	ID      string `json:"id" required:"true"`
@@ -110,7 +105,7 @@ type ParticipantProfile struct {
 
 type VirtualParticipantAgent struct {
 	DeployableEntity
-	Type       model.VPAType  `json:"type" required:"true"`
+	Type       common.VPAType `json:"type" required:"true"`
 	CellID     string         `json:"cellId" required:"true"`
 	Properties map[string]any `json:"properties,omitempty"`
 }
@@ -129,49 +124,20 @@ type TenantPropertiesDiff struct {
 // KeyRotationRequest represents a request to rotate a key, with optional parameters for algorithm (default: eddsa), curve (default: ed25519), and
 // grace period (default: P3M, 3 months).
 type KeyRotationRequest struct {
-	KeyID       string          `json:"keyId" required:"true"`
-	Algorithm   string          `json:"algorithm,omitempty"`
-	Curve       string          `json:"curve,omitempty"`
-	GracePeriod DurationISO8601 `json:"gracePeriod,omitempty"`
+	KeyID       string                  `json:"keyId" required:"true"`
+	Algorithm   string                  `json:"algorithm,omitempty"`
+	Curve       string                  `json:"curve,omitempty"`
+	GracePeriod *common.DurationISO8601 `json:"gracePeriod,omitempty"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface to provide default values
 func (r *KeyRotationRequest) UnmarshalJSON(b []byte) error {
 	r.Algorithm = "eddsa"
 	r.Curve = "ed25519"
-	r.GracePeriod = NewDuration("P3M")
+	d := common.NewDuration("P3M")
+	r.GracePeriod = &d
 
 	// use a type alias to break infinite recursion
 	type Alias KeyRotationRequest
 	return json.Unmarshal(b, (*Alias)(r))
-}
-
-// DurationISO8601 is an ISO 8601 duration (e.g. "P3M", "P1Y2M3DT4H5M6S").
-type DurationISO8601 struct {
-	raw string
-}
-
-// NewDuration creates a new DurationISO8601 from a string and panics if the string is not a valid ISO 8601 duration.
-func NewDuration(s string) DurationISO8601 {
-	if !iso8601DurationRe.MatchString(s) {
-		panic(fmt.Errorf("invalid ISO 8601 duration: %q", s))
-	}
-	return DurationISO8601{raw: s}
-}
-
-func (d *DurationISO8601) String() string {
-	return d.raw
-}
-
-func (d *DurationISO8601) UnmarshalJSON(b []byte) error {
-	s := strings.Trim(string(b), `"`)
-	if !iso8601DurationRe.MatchString(s) {
-		return fmt.Errorf("invalid ISO 8601 duration: %q", s)
-	}
-	d.raw = s
-	return nil
-}
-
-func (d *DurationISO8601) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + d.raw + `"`), nil
 }

--- a/tmanager/model/v1alpha1/model.go
+++ b/tmanager/model/v1alpha1/model.go
@@ -124,7 +124,7 @@ type TenantPropertiesDiff struct {
 // KeyRotationRequest represents a request to rotate a key, with optional parameters for algorithm (default: eddsa), curve (default: ed25519), and
 // grace period (default: P3M, 3 months).
 type KeyRotationRequest struct {
-	KeyID       string                  `json:"keyId" required:"true"`
+	KeyPairID   string                  `json:"keyPairId" required:"true"`
 	Algorithm   string                  `json:"algorithm,omitempty"`
 	Curve       string                  `json:"curve,omitempty"`
 	GracePeriod *common.DurationISO8601 `json:"gracePeriod,omitempty"`

--- a/tmanager/model/v1alpha1/model_test.go
+++ b/tmanager/model/v1alpha1/model_test.go
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyRotationRequest_Serialization(t *testing.T) {
+	req := &KeyRotationRequest{
+		KeyID: "test-key-id",
+	}
+
+	jsonData, err := json.Marshal(req)
+	require.NoError(t, err)
+	assert.Contains(t, string(jsonData), `"keyId":"test-key-id"`)
+}
+
+func TestKeyRotationRequest_Deserialization(t *testing.T) {
+	jsonData := `{"keyId": "test-key-id", "algorithm": "EcDSA", "curve": "P-256", "gracePeriod": "P6M"}`
+
+	var req KeyRotationRequest
+	err := json.Unmarshal([]byte(jsonData), &req)
+	require.NoError(t, err)
+	require.Equal(t, "test-key-id", req.KeyID)
+	require.Equal(t, "EcDSA", req.Algorithm)
+	require.Equal(t, "P-256", req.Curve)
+	require.Equal(t, "P6M", req.GracePeriod.String())
+}
+
+func TestKeyRotationRequest_RoundTrip(t *testing.T) {
+	req := &KeyRotationRequest{
+		KeyID:       "test-key-id",
+		Algorithm:   "eddsa",
+		Curve:       "ed25519",
+		GracePeriod: NewDuration("P1Y2M3DT4H"),
+	}
+	jsonData, err := json.Marshal(req)
+	require.NoError(t, err)
+	require.NotNil(t, jsonData)
+
+	deser := KeyRotationRequest{}
+	err = json.Unmarshal(jsonData, &deser)
+	require.NoError(t, err)
+	require.Equal(t, req, &deser)
+}
+
+func TestKeyRotationRequest_VerifyDefaults(t *testing.T) {
+	jsonData := `{"keyId": "test-key-id"}`
+
+	request := KeyRotationRequest{}
+	err := json.Unmarshal([]byte(jsonData), &request)
+	require.NoError(t, err)
+
+	require.Equal(t, "eddsa", request.Algorithm)
+	require.Equal(t, "ed25519", request.Curve)
+	require.Equal(t, "P3M", request.GracePeriod.String())
+}

--- a/tmanager/model/v1alpha1/model_test.go
+++ b/tmanager/model/v1alpha1/model_test.go
@@ -25,21 +25,21 @@ import (
 
 func TestKeyRotationRequest_Serialization(t *testing.T) {
 	req := &KeyRotationRequest{
-		KeyID: "test-key-id",
+		KeyPairID: "test-key-id",
 	}
 
 	jsonData, err := json.Marshal(req)
 	require.NoError(t, err)
-	assert.Contains(t, string(jsonData), `"keyId":"test-key-id"`)
+	assert.Contains(t, string(jsonData), `"keyPairId":"test-key-id"`)
 }
 
 func TestKeyRotationRequest_Deserialization(t *testing.T) {
-	jsonData := `{"keyId": "test-key-id", "algorithm": "EcDSA", "curve": "P-256", "gracePeriod": "P6M"}`
+	jsonData := `{"keyPairId": "test-key-id", "algorithm": "EcDSA", "curve": "P-256", "gracePeriod": "P6M"}`
 
 	var req KeyRotationRequest
 	err := json.Unmarshal([]byte(jsonData), &req)
 	require.NoError(t, err)
-	require.Equal(t, "test-key-id", req.KeyID)
+	require.Equal(t, "test-key-id", req.KeyPairID)
 	require.Equal(t, "EcDSA", req.Algorithm)
 	require.Equal(t, "P-256", req.Curve)
 	require.Equal(t, "P6M", req.GracePeriod.String())
@@ -48,7 +48,7 @@ func TestKeyRotationRequest_Deserialization(t *testing.T) {
 func TestKeyRotationRequest_RoundTrip(t *testing.T) {
 	gracePeriod := common.NewDuration("P1Y2M3DT4H")
 	req := &KeyRotationRequest{
-		KeyID:       "test-key-id",
+		KeyPairID:   "test-key-id",
 		Algorithm:   "eddsa",
 		Curve:       "ed25519",
 		GracePeriod: &gracePeriod,
@@ -64,7 +64,7 @@ func TestKeyRotationRequest_RoundTrip(t *testing.T) {
 }
 
 func TestKeyRotationRequest_VerifyDefaults(t *testing.T) {
-	jsonData := `{"keyId": "test-key-id"}`
+	jsonData := `{"keyPairId": "test-key-id"}`
 
 	request := KeyRotationRequest{}
 	err := json.Unmarshal([]byte(jsonData), &request)

--- a/tmanager/model/v1alpha1/model_test.go
+++ b/tmanager/model/v1alpha1/model_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	common "github.com/eclipse-cfm/cfm/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -45,11 +46,12 @@ func TestKeyRotationRequest_Deserialization(t *testing.T) {
 }
 
 func TestKeyRotationRequest_RoundTrip(t *testing.T) {
+	gracePeriod := common.NewDuration("P1Y2M3DT4H")
 	req := &KeyRotationRequest{
 		KeyID:       "test-key-id",
 		Algorithm:   "eddsa",
 		Curve:       "ed25519",
-		GracePeriod: NewDuration("P1Y2M3DT4H"),
+		GracePeriod: &gracePeriod,
 	}
 	jsonData, err := json.Marshal(req)
 	require.NoError(t, err)

--- a/tmanager/model/v1alpha1/transformers.go
+++ b/tmanager/model/v1alpha1/transformers.go
@@ -269,3 +269,12 @@ func ToDataspaceProfile(input *api.DataspaceProfile) *DataspaceProfile {
 		Properties:  input.Properties,
 	}
 }
+
+func ToKeyRotationRequest(input *KeyRotationRequest) api.KeyRotationRequest {
+	return api.KeyRotationRequest{
+		KeyID:       input.KeyID,
+		Algorithm:   input.Algorithm,
+		Curve:       input.Curve,
+		GracePeriod: input.GracePeriod,
+	}
+}

--- a/tmanager/model/v1alpha1/transformers.go
+++ b/tmanager/model/v1alpha1/transformers.go
@@ -272,7 +272,7 @@ func ToDataspaceProfile(input *api.DataspaceProfile) *DataspaceProfile {
 
 func ToKeyRotationRequest(input *KeyRotationRequest) api.KeyRotationRequest {
 	return api.KeyRotationRequest{
-		KeyID:       input.KeyID,
+		KeyPairID:   input.KeyPairID,
 		Algorithm:   input.Algorithm,
 		Curve:       input.Curve,
 		GracePeriod: input.GracePeriod,

--- a/tmanager/model/v1alpha1/transformers_test.go
+++ b/tmanager/model/v1alpha1/transformers_test.go
@@ -1100,3 +1100,35 @@ func TestToAPINewParticipantProfileDeployment_NilValuesHandling(t *testing.T) {
 	assert.NotNil(t, result.Properties, "Properties should not be nil")
 	assert.Len(t, result.Properties, 0, "Properties should be empty map")
 }
+
+func TestToKeyRotationRequest_NilGracePeriod(t *testing.T) {
+
+	input := &KeyRotationRequest{
+		KeyID:       "key-id",
+		Algorithm:   "algorithm",
+		Curve:       "curve",
+		GracePeriod: nil,
+	}
+	output := ToKeyRotationRequest(input)
+	require.NotNil(t, output)
+	require.Equal(t, input.KeyID, output.KeyID)
+	require.Equal(t, input.Algorithm, output.Algorithm)
+	require.Equal(t, input.Curve, output.Curve)
+	require.Nil(t, output.GracePeriod)
+}
+
+func TestToKeyRotationRequest(t *testing.T) {
+
+	input := &KeyRotationRequest{
+		KeyID:       "key-id",
+		Algorithm:   "algorithm",
+		Curve:       "curve",
+		GracePeriod: &model.DurationISO8601{},
+	}
+	output := ToKeyRotationRequest(input)
+	require.NotNil(t, output)
+	require.Equal(t, input.KeyID, output.KeyID)
+	require.Equal(t, input.Algorithm, output.Algorithm)
+	require.Equal(t, input.Curve, output.Curve)
+	require.Equal(t, input.GracePeriod, output.GracePeriod)
+}

--- a/tmanager/model/v1alpha1/transformers_test.go
+++ b/tmanager/model/v1alpha1/transformers_test.go
@@ -1104,14 +1104,14 @@ func TestToAPINewParticipantProfileDeployment_NilValuesHandling(t *testing.T) {
 func TestToKeyRotationRequest_NilGracePeriod(t *testing.T) {
 
 	input := &KeyRotationRequest{
-		KeyID:       "key-id",
+		KeyPairID:   "key-id",
 		Algorithm:   "algorithm",
 		Curve:       "curve",
 		GracePeriod: nil,
 	}
 	output := ToKeyRotationRequest(input)
 	require.NotNil(t, output)
-	require.Equal(t, input.KeyID, output.KeyID)
+	require.Equal(t, input.KeyPairID, output.KeyPairID)
 	require.Equal(t, input.Algorithm, output.Algorithm)
 	require.Equal(t, input.Curve, output.Curve)
 	require.Nil(t, output.GracePeriod)
@@ -1120,14 +1120,14 @@ func TestToKeyRotationRequest_NilGracePeriod(t *testing.T) {
 func TestToKeyRotationRequest(t *testing.T) {
 
 	input := &KeyRotationRequest{
-		KeyID:       "key-id",
+		KeyPairID:   "key-id",
 		Algorithm:   "algorithm",
 		Curve:       "curve",
 		GracePeriod: &model.DurationISO8601{},
 	}
 	output := ToKeyRotationRequest(input)
 	require.NotNil(t, output)
-	require.Equal(t, input.KeyID, output.KeyID)
+	require.Equal(t, input.KeyPairID, output.KeyPairID)
 	require.Equal(t, input.Algorithm, output.Algorithm)
 	require.Equal(t, input.Curve, output.Curve)
 	require.Equal(t, input.GracePeriod, output.GracePeriod)


### PR DESCRIPTION
## Summary

- Adds a new `/rotate-keys` REST endpoint on the tenant manager (`POST /tenants/{tenantId}/participant-profiles/{profileId}/rotate-keys`) that accepts a `KeyRotationRequest` and triggers key rotation in the IdentityHub 
- Introduces a new agent (`ih-keyrotate`) that executes the IdentityHub key rotation API call, generating a fresh key ID and forwarding the request body (algorithm, curve, grace period) to IdentityHub.

- an agent to rotate keys in the Vault will come in another PR


Closes https://github.com/eclipse-cfm/planning/issues/53 