### PR TITLE
fix: use correct API base path

### DIFF
--- a/agent/common/identityhub/identityhub.go
+++ b/agent/common/identityhub/identityhub.go
@@ -72,7 +72,7 @@ func (a HttpIdentityAPIClient) RotateKey(ctx context.Context, participantContext
 		return fmt.Errorf("failed to get API access token: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/participants/%s/keypairs/%s/rotate", a.BaseURL, participantContextID, keyRotationParams.KeyPairID)
+	url := fmt.Sprintf("%s/v1alpha/participants/%s/keypairs/%s/rotate", a.BaseURL, participantContextID, keyRotationParams.KeyPairID)
 	body := keyDescriptor{
 		KeyID:           keyId,
 		PrivateKeyAlias: keyId,

--- a/agent/common/identityhub/identityhub_test.go
+++ b/agent/common/identityhub/identityhub_test.go
@@ -171,7 +171,7 @@ func TestHttpIdentityAPIClient_DeleteParticipantContext(t *testing.T) {
 
 func TestHttpIdentityAPIClient_RotateKey(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/participants/test-participant/keypairs/test-keypair-id/rotate" && r.Method == http.MethodPost {
+		if r.URL.Path == "/v1alpha/participants/test-participant/keypairs/test-keypair-id/rotate" && r.Method == http.MethodPost {
 			require.Equal(t, "Bearer token", r.Header.Get("Authorization"))
 			require.Equal(t, "application/json", r.Header.Get("Content-Type"))
 


### PR DESCRIPTION
prepend `/v1alpha` to all IdentityHUB API paths
