### PR TITLE
fix: use random UUID as private key alias for participant manifests

### DIFF
--- a/agent/common/identityhub/types.go
+++ b/agent/common/identityhub/types.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	commonvault "github.com/eclipse-cfm/cfm/agent/common/vault"
+	"github.com/google/uuid"
 )
 
 const (
@@ -85,7 +86,7 @@ func NewParticipantManifest(
 		IsActive:             true,
 		KeyGeneratorParameters: KeyGeneratorParameters{
 			KeyID:           DefaultKeyID,
-			PrivateKeyAlias: DefaultKeyID,
+			PrivateKeyAlias: uuid.NewString(),
 			KeyAlgorithm:    DefaultAlgorithm,
 			Curve:           DefaultCurve,
 		},
@@ -103,9 +104,7 @@ func NewParticipantManifest(
 		if !strings.HasPrefix(sanitizedKeyID, "#") {
 			sanitizedKeyID = "#" + sanitizedKeyID
 		}
-		sanitizedKeyID = did + sanitizedKeyID
-		manifest.KeyGeneratorParameters.KeyID = sanitizedKeyID
-		manifest.KeyGeneratorParameters.PrivateKeyAlias = sanitizedKeyID
+		manifest.KeyGeneratorParameters.KeyID = did + sanitizedKeyID
 	}
 
 	return manifest

--- a/agent/common/identityhub/types_test.go
+++ b/agent/common/identityhub/types_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,7 +29,8 @@ func TestNewParticipantManifest_WithDefaults(t *testing.T) {
 	require.Equal(t, manifest.ProtocolServiceID, "test-id-dsp")
 	require.Equal(t, manifest.IsActive, true)
 	require.Equal(t, manifest.KeyGeneratorParameters.KeyID, "did:web:foo#"+DefaultKeyID)
-	require.Equal(t, manifest.KeyGeneratorParameters.PrivateKeyAlias, "did:web:foo#"+DefaultKeyID)
+	_, err := uuid.Parse(manifest.KeyGeneratorParameters.PrivateKeyAlias)
+	require.NoError(t, err)
 	require.Equal(t, manifest.VaultConfig.SecretPath, "v1/participants")
 	require.Equal(t, manifest.VaultConfig.FolderPath, "test-id/identityhub")
 }

--- a/assembly/vault/fixtures.go
+++ b/assembly/vault/fixtures.go
@@ -26,6 +26,7 @@ import (
 	"github.com/eclipse-cfm/cfm/assembly/serviceapi"
 	"github.com/eclipse-cfm/cfm/common/system"
 	"github.com/google/uuid"
+	"github.com/moby/moby/api/types/container"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/network"
@@ -66,6 +67,9 @@ func StartVaultContainer(ctx context.Context, networkName string) (*ContainerRes
 		ExposedPorts: []string{vaultPort},
 		Networks:     []string{networkName},
 		Name:         name,
+		HostConfigModifier: func(hc *container.HostConfig) {
+			hc.CapAdd = append(hc.CapAdd, "IPC_LOCK")
+		},
 		Env: map[string]string{
 			"VAULT_DEV_ROOT_TOKEN_ID": vaultRootToken,
 			"SKIP_SETCAP":             "true", // this is required to run as non-root user in some environments, such as M1 macs


### PR DESCRIPTION
## Summary
- Replace the static `KeyID` reuse for `PrivateKeyAlias` with a randomly generated UUID (`uuid.NewString()`)
- Each participant manifest now gets a unique, unpredictable vault alias, preventing potential alias collisions
- Update test to verify the alias is a valid UUID instead of asserting a fixed value

## Why

key aliases are constrained w.r.t. to special characters in some environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)