### PR TITLE
feat: add jwtlet agent and token-exchange provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ IH_DIR=agent/ih
 KEYCLOAK_DIR=agent/keycloak
 REG_DIR=agent/registration
 ONBOARDING_DIR=agent/onboarding
+JWTLET_AGENT_DIR=agent/jwtlet-agent
 AGENT_COMMON=agent/common
 KIND_CLUSTER_NAME=edcv
 
@@ -71,6 +72,7 @@ build:
 	$(MAKE) -C $(KEYCLOAK_DIR) build
 	$(MAKE) -C $(REG_DIR) build
 	$(MAKE) -C $(ONBOARDING_DIR) build
+	$(MAKE) -C $(JWTLET_AGENT_DIR) build
 
 build-pmanager:
 	@echo "Building pmanager..."
@@ -89,6 +91,7 @@ build-all:
 	$(MAKE) -C $(KEYCLOAK_DIR) build-all
 	$(MAKE) -C $(REG_DIR) build-all
 	$(MAKE) -C $(ONBOARDING_DIR) build-all
+	$(MAKE) -C $(JWTLET_AGENT_DIR) build-all
 
 #==============================================================================
 # Test Commands - Delegate to Service Makefiles
@@ -105,6 +108,7 @@ test: install-gotestsum
 	$(MAKE) -C $(KEYCLOAK_DIR) test
 	$(MAKE) -C $(REG_DIR) test
 	$(MAKE) -C $(ONBOARDING_DIR) test
+	$(MAKE) -C $(JWTLET_AGENT_DIR) test
 	$(MAKE) -C $(ASSEMBLY_DIR) test
 	$(MAKE) -C $(AGENT_COMMON) test
 
@@ -157,6 +161,7 @@ clean:
 	$(MAKE) -C $(IH_DIR) clean
 	$(MAKE) -C $(REG_DIR) clean
 	$(MAKE) -C $(ONBOARDING_DIR) clean
+	$(MAKE) -C $(JWTLET_AGENT_DIR) clean
 
 #==============================================================================
 # Tool Commands - Delegate to Service Makefiles
@@ -187,7 +192,7 @@ generate-docs:
 # Docker Commands - Handled at Top Level
 #==============================================================================
 
-docker-build: docker-build-pmanager docker-build-tmanager docker-build-testagent docker-build-edcvagent docker-build-ihagent docker-build-kcagent docker-build-regagent docker-build-obagent
+docker-build: docker-build-pmanager docker-build-tmanager docker-build-jwtletagent docker-build-edcvagent docker-build-ihagent docker-build-kcagent docker-build-regagent docker-build-obagent
 
 docker-build-pmanager:
 	@echo "Building pmanager Docker image..."
@@ -197,9 +202,9 @@ docker-build-tmanager:
 	@echo "Building tmanager Docker image..."
 	docker buildx build -f docker/Dockerfile.tmanager.dockerfile -t $(DOCKER_REGISTRY)tmanager:$(DOCKER_TAG) .
 
-docker-build-testagent:
+docker-build-jwtletagent:
 	@echo "Building test agent Docker image..."
-	docker buildx build -f docker/Dockerfile.testagent.dockerfile -t $(DOCKER_REGISTRY)testagent:$(DOCKER_TAG) .
+	docker buildx build -f docker/Dockerfile.jwtletagent.dockerfile -t $(DOCKER_REGISTRY)jwtletagent:$(DOCKER_TAG) .
 
 docker-build-edcvagent:
 	@echo "Building EDC-V agent Docker image..."
@@ -221,7 +226,7 @@ docker-build-obagent:
 	@echo "Building Onboarding agent Docker image..."
 	docker buildx build -f docker/Dockerfile.obagent.dockerfile -t $(DOCKER_REGISTRY)obagent:$(DOCKER_TAG) .
 
-docker-clean: docker-clean-pmanager docker-clean-tmanager docker-clean-testagent docker-clean-edcvagent docker-clean-ihagent docker-clean-regagent docker-clean-obagent
+docker-clean: docker-clean-pmanager docker-clean-tmanager docker-clean-jwtletagent docker-clean-edcvagent docker-clean-ihagent docker-clean-regagent docker-clean-obagent
 
 docker-clean-pmanager:
 	docker rmi $(DOCKER_REGISTRY)pmanager:$(DOCKER_TAG) || true
@@ -229,8 +234,8 @@ docker-clean-pmanager:
 docker-clean-tmanager:
 	docker rmi $(DOCKER_REGISTRY)tmanager:$(DOCKER_TAG) || true
 
-docker-clean-testagent:
-	docker rmi $(DOCKER_REGISTRY)testagent:$(DOCKER_TAG) || true
+docker-clean-jwtletagent:
+	docker rmi $(DOCKER_REGISTRY)jwtletagent:$(DOCKER_TAG) || true
 
 docker-clean-edcvagent:
 	docker rmi $(DOCKER_REGISTRY)edcvagent:$(DOCKER_TAG) || true
@@ -268,6 +273,9 @@ load-into-kind-obagent: docker-build-obagent
 
 load-into-kind-regagent: docker-build-regagent
 	kind load docker-image -n $(KIND_CLUSTER_NAME) $(DOCKER_REGISTRY)regagent:$(DOCKER_TAG)
+
+load-into-kind-jwtletagent: docker-build-jwtletagent
+	kind load docker-image -n $(KIND_CLUSTER_NAME) $(DOCKER_REGISTRY)jwtletagent:$(DOCKER_TAG)
 
 # builds and loads all images into KinD cluster. Will require kind to be installed and a kind cluster named KIND_CLUSTER_NAME running.
 load-into-kind: docker-build

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ test: install-gotestsum
 	$(MAKE) -C $(PMANAGER_DIR) test
 	$(MAKE) -C $(TMANAGER_DIR) test
 	$(MAKE) -C $(EDCV_DIR) test
+	$(MAKE) -C $(JWTLET_AGENT_DIR) test
 	$(MAKE) -C $(IH_DIR) test
 	$(MAKE) -C $(E2E_DIR) test
 	$(MAKE) -C $(KEYCLOAK_DIR) test

--- a/agent/common/identityhub/identityhub.go
+++ b/agent/common/identityhub/identityhub.go
@@ -31,8 +31,9 @@ const (
 	CredentialRequestStateCreated = "CREATED"
 	CredentialRequestStateIssued  = "ISSUED"
 	CredentialRequestStateError   = "ERROR"
-	ScopeApiRead                  = "read admin"  //todo: replace with participant scoped token
-	ScopeApiWrite                 = "write admin" // todo: replace with participant scoped token
+	ScopeApiRead                  = "read"
+	ScopeApiWrite                 = "write"
+	ScopeApiAdmin                 = "admin"
 )
 
 type IdentityAPIClient interface {
@@ -50,7 +51,7 @@ type HttpIdentityAPIClient struct {
 }
 
 func (a HttpIdentityAPIClient) DeleteParticipantContext(ctx context.Context, participantContextID string) error {
-	accessToken, err := a.TokenProvider.GetToken(ctx, ScopeApiWrite, participantContextID)
+	accessToken, err := a.TokenProvider.GetToken(ctx, ScopeApiAdmin, participantContextID)
 	if err != nil {
 		return fmt.Errorf("failed to get API access token: %w", err)
 	}
@@ -189,7 +190,7 @@ func (a HttpIdentityAPIClient) GetCredentialRequestState(ctx context.Context, pa
 }
 
 func (a HttpIdentityAPIClient) CreateParticipantContext(ctx context.Context, manifest ParticipantManifest) (*CreateParticipantContextResponse, error) {
-	accessToken, err := a.TokenProvider.GetToken(ctx, ScopeApiWrite, manifest.ParticipantContextID)
+	accessToken, err := a.TokenProvider.GetToken(ctx, ScopeApiAdmin, manifest.ParticipantContextID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get API access token: %w", err)
 	}

--- a/agent/common/identityhub/identityhub.go
+++ b/agent/common/identityhub/identityhub.go
@@ -27,13 +27,12 @@ import (
 )
 
 const (
-	CreateParticipantURL = "/v1beta/participants"
-)
-
-const (
+	CreateParticipantURL          = "/v1beta/participants"
 	CredentialRequestStateCreated = "CREATED"
 	CredentialRequestStateIssued  = "ISSUED"
 	CredentialRequestStateError   = "ERROR"
+	ScopeApiRead                  = "identity-api:read"
+	ScopeApiWrite                 = "identity-api:write"
 )
 
 type IdentityAPIClient interface {
@@ -51,7 +50,7 @@ type HttpIdentityAPIClient struct {
 }
 
 func (a HttpIdentityAPIClient) DeleteParticipantContext(ctx context.Context, participantContextID string) error {
-	accessToken, err := a.TokenProvider.GetToken(ctx)
+	accessToken, err := a.TokenProvider.GetToken(ctx, ScopeApiWrite, participantContextID)
 	if err != nil {
 		return fmt.Errorf("failed to get API access token: %w", err)
 	}
@@ -80,7 +79,7 @@ func (a HttpIdentityAPIClient) DeleteParticipantContext(ctx context.Context, par
 
 func (a HttpIdentityAPIClient) QueryCredentialByType(ctx context.Context, participantContextID string, credentialType string) ([]common.VerifiableCredentialResource, error) {
 
-	accessToken, err := a.TokenProvider.GetToken(ctx)
+	accessToken, err := a.TokenProvider.GetToken(ctx, ScopeApiRead, participantContextID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get API access token: %w", err)
 	}
@@ -114,7 +113,7 @@ func (a HttpIdentityAPIClient) QueryCredentialByType(ctx context.Context, partic
 }
 
 func (a HttpIdentityAPIClient) RequestCredentials(ctx context.Context, participantContextID string, credentialRequest CredentialRequest) (string, error) {
-	accessToken, err := a.TokenProvider.GetToken(ctx) // this should be the participant context's access token!
+	accessToken, err := a.TokenProvider.GetToken(ctx, ScopeApiWrite, participantContextID) // this should be the participant context's access token!
 	if err != nil {
 		return "", fmt.Errorf("failed to get API access token: %w", err)
 	}
@@ -151,7 +150,7 @@ func (a HttpIdentityAPIClient) RequestCredentials(ctx context.Context, participa
 }
 
 func (a HttpIdentityAPIClient) GetCredentialRequestState(ctx context.Context, participantContextID string, credentialRequestID string) (string, error) {
-	accessToken, err := a.TokenProvider.GetToken(ctx)
+	accessToken, err := a.TokenProvider.GetToken(ctx, ScopeApiRead, participantContextID)
 	if err != nil {
 		return "", fmt.Errorf("failed to get API access token: %w", err)
 	}
@@ -190,7 +189,7 @@ func (a HttpIdentityAPIClient) GetCredentialRequestState(ctx context.Context, pa
 }
 
 func (a HttpIdentityAPIClient) CreateParticipantContext(ctx context.Context, manifest ParticipantManifest) (*CreateParticipantContextResponse, error) {
-	accessToken, err := a.TokenProvider.GetToken(ctx)
+	accessToken, err := a.TokenProvider.GetToken(ctx, ScopeApiWrite, manifest.DID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get API access token: %w", err)
 	}

--- a/agent/common/identityhub/identityhub.go
+++ b/agent/common/identityhub/identityhub.go
@@ -31,8 +31,8 @@ const (
 	CredentialRequestStateCreated = "CREATED"
 	CredentialRequestStateIssued  = "ISSUED"
 	CredentialRequestStateError   = "ERROR"
-	ScopeApiRead                  = "read"
-	ScopeApiWrite                 = "write"
+	ScopeApiRead                  = "read admin"  //todo: replace with participant scoped token
+	ScopeApiWrite                 = "write admin" // todo: replace with participant scoped token
 )
 
 type IdentityAPIClient interface {

--- a/agent/common/identityhub/identityhub.go
+++ b/agent/common/identityhub/identityhub.go
@@ -31,8 +31,8 @@ const (
 	CredentialRequestStateCreated = "CREATED"
 	CredentialRequestStateIssued  = "ISSUED"
 	CredentialRequestStateError   = "ERROR"
-	ScopeApiRead                  = "identity-api:read"
-	ScopeApiWrite                 = "identity-api:write"
+	ScopeApiRead                  = "read"
+	ScopeApiWrite                 = "write"
 )
 
 type IdentityAPIClient interface {
@@ -189,7 +189,7 @@ func (a HttpIdentityAPIClient) GetCredentialRequestState(ctx context.Context, pa
 }
 
 func (a HttpIdentityAPIClient) CreateParticipantContext(ctx context.Context, manifest ParticipantManifest) (*CreateParticipantContextResponse, error) {
-	accessToken, err := a.TokenProvider.GetToken(ctx, ScopeApiWrite, manifest.DID)
+	accessToken, err := a.TokenProvider.GetToken(ctx, ScopeApiWrite, manifest.ParticipantContextID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get API access token: %w", err)
 	}

--- a/agent/common/identityhub/identityhub_test.go
+++ b/agent/common/identityhub/identityhub_test.go
@@ -77,7 +77,7 @@ func TestIdentityAPIClient_CreateParticipantContext(t *testing.T) {
 	defer server.Close()
 
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("token", nil)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("token", nil)
 	client := HttpIdentityAPIClient{
 		BaseURL:       server.URL,
 		TokenProvider: tp,
@@ -100,7 +100,7 @@ func TestIdentityAPIClient_CreateParticipantContext(t *testing.T) {
 
 func TestIdentityAPIClient_AuthError(t *testing.T) {
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("", fmt.Errorf("test error"))
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("", fmt.Errorf("test error"))
 	client := HttpIdentityAPIClient{
 		BaseURL:       "http://foo.bar",
 		TokenProvider: tp,
@@ -128,7 +128,7 @@ func TestIdentityAPIClient_BadRequest(t *testing.T) {
 	defer server.Close()
 
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("token", nil)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("token", nil)
 	client := HttpIdentityAPIClient{
 		BaseURL:       server.URL,
 		TokenProvider: tp,
@@ -161,7 +161,7 @@ func TestHttpIdentityAPIClient_DeleteParticipantContext(t *testing.T) {
 	defer server.Close()
 
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("token", nil)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("token", nil)
 	client := HttpIdentityAPIClient{
 		BaseURL:       server.URL,
 		TokenProvider: tp,
@@ -180,7 +180,7 @@ func TestHttpIdentityAPIClient_DeleteParticipantContext_NotFound(t *testing.T) {
 	defer server.Close()
 
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("token", nil)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("token", nil)
 	client := HttpIdentityAPIClient{
 		BaseURL:       server.URL,
 		TokenProvider: tp,

--- a/agent/common/issuerservice/issuer.go
+++ b/agent/common/issuerservice/issuer.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	ScopeApiRead  = "issuer-admin-api:read"
-	ScopeApiWrite = "issuer-admin-api:write"
+	ScopeApiRead  = "read admin"
+	ScopeApiWrite = "write admin"
 )
 
 // IssuerCredentialResourceDto represents a DTO for verifiable credentials that the IssuerService has issued to holders.
@@ -42,8 +42,8 @@ type IssuerCredentialResourceDto struct {
 }
 
 type ApiClient interface {
-	CreateHolder(ctx context.Context, did string, holderID string, name string, properties map[string]any) error
-	DeleteHolder(ctx context.Context, holderID string) error
+	CreateHolder(ctx context.Context, participantContextID string, did string, holderID string, name string, properties map[string]any) error
+	DeleteHolder(ctx context.Context, participantContextID string, holderID string) error
 	RevokeCredential(ctx context.Context, participantContextID string, credentialID string) error
 	QueryCredentialsByType(ctx context.Context, participantContextID string, credentialType string) ([]IssuerCredentialResourceDto, error)
 }
@@ -109,8 +109,8 @@ func (i HttpApiClient) QueryCredentialsByType(ctx context.Context, holderID stri
 	return credentials, nil
 }
 
-func (i HttpApiClient) DeleteHolder(ctx context.Context, holderID string) error {
-	accessToken, err := i.TokenProvider.GetToken(ctx, ScopeApiWrite, holderID)
+func (i HttpApiClient) DeleteHolder(ctx context.Context, participantContextID string, holderID string) error {
+	accessToken, err := i.TokenProvider.GetToken(ctx, ScopeApiWrite, participantContextID)
 	if err != nil {
 		return fmt.Errorf("failed to get API access token: %w", err)
 	}
@@ -138,8 +138,8 @@ func (i HttpApiClient) DeleteHolder(ctx context.Context, holderID string) error 
 	return nil
 }
 
-func (i HttpApiClient) CreateHolder(ctx context.Context, did string, holderID string, name string, properties map[string]any) error {
-	accessToken, err := i.TokenProvider.GetToken(ctx, ScopeApiWrite, holderID)
+func (i HttpApiClient) CreateHolder(ctx context.Context, participantContextID string, did string, holderID string, name string, properties map[string]any) error {
+	accessToken, err := i.TokenProvider.GetToken(ctx, ScopeApiWrite, participantContextID)
 	if err != nil {
 		return fmt.Errorf("failed to get API access token: %w", err)
 	}

--- a/agent/common/issuerservice/issuer.go
+++ b/agent/common/issuerservice/issuer.go
@@ -26,6 +26,11 @@ import (
 	"github.com/eclipse-cfm/cfm/common/token"
 )
 
+const (
+	ScopeApiRead  = "issuer-admin-api:read"
+	ScopeApiWrite = "issuer-admin-api:write"
+)
+
 // IssuerCredentialResourceDto represents a DTO for verifiable credentials that the IssuerService has issued to holders.
 // note that these DTOs are simplified representations of the actual verifiable credentials and NEVER include the actual
 // signed credential
@@ -51,7 +56,7 @@ type HttpApiClient struct {
 }
 
 func (i HttpApiClient) QueryCredentialsByType(ctx context.Context, holderID string, credentialType string) ([]IssuerCredentialResourceDto, error) {
-	accessToken, err := i.TokenProvider.GetToken(ctx)
+	accessToken, err := i.TokenProvider.GetToken(ctx, ScopeApiRead, holderID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get API access token: %w", err)
 	}
@@ -105,7 +110,7 @@ func (i HttpApiClient) QueryCredentialsByType(ctx context.Context, holderID stri
 }
 
 func (i HttpApiClient) DeleteHolder(ctx context.Context, holderID string) error {
-	accessToken, err := i.TokenProvider.GetToken(ctx)
+	accessToken, err := i.TokenProvider.GetToken(ctx, ScopeApiWrite, holderID)
 	if err != nil {
 		return fmt.Errorf("failed to get API access token: %w", err)
 	}
@@ -134,7 +139,7 @@ func (i HttpApiClient) DeleteHolder(ctx context.Context, holderID string) error 
 }
 
 func (i HttpApiClient) CreateHolder(ctx context.Context, did string, holderID string, name string, properties map[string]any) error {
-	accessToken, err := i.TokenProvider.GetToken(ctx)
+	accessToken, err := i.TokenProvider.GetToken(ctx, ScopeApiWrite, holderID)
 	if err != nil {
 		return fmt.Errorf("failed to get API access token: %w", err)
 	}
@@ -180,7 +185,7 @@ func (i HttpApiClient) CreateHolder(ctx context.Context, did string, holderID st
 }
 
 func (i HttpApiClient) RevokeCredential(ctx context.Context, participantContextID string, credentialID string) error {
-	accessToken, err := i.TokenProvider.GetToken(ctx)
+	accessToken, err := i.TokenProvider.GetToken(ctx, ScopeApiWrite, participantContextID)
 	if err != nil {
 		return err
 	}

--- a/agent/common/issuerservice/issuer.go
+++ b/agent/common/issuerservice/issuer.go
@@ -27,8 +27,9 @@ import (
 )
 
 const (
-	ScopeApiRead  = "read admin"
-	ScopeApiWrite = "write admin"
+	ScopeApiRead  = "read"
+	ScopeApiWrite = "write"
+	ScopeApiAdmin = "admin"
 )
 
 // IssuerCredentialResourceDto represents a DTO for verifiable credentials that the IssuerService has issued to holders.
@@ -110,7 +111,7 @@ func (i HttpApiClient) QueryCredentialsByType(ctx context.Context, holderID stri
 }
 
 func (i HttpApiClient) DeleteHolder(ctx context.Context, participantContextID string, holderID string) error {
-	accessToken, err := i.TokenProvider.GetToken(ctx, ScopeApiWrite, participantContextID)
+	accessToken, err := i.TokenProvider.GetToken(ctx, ScopeApiAdmin, participantContextID)
 	if err != nil {
 		return fmt.Errorf("failed to get API access token: %w", err)
 	}
@@ -139,7 +140,7 @@ func (i HttpApiClient) DeleteHolder(ctx context.Context, participantContextID st
 }
 
 func (i HttpApiClient) CreateHolder(ctx context.Context, participantContextID string, did string, holderID string, name string, properties map[string]any) error {
-	accessToken, err := i.TokenProvider.GetToken(ctx, ScopeApiWrite, participantContextID)
+	accessToken, err := i.TokenProvider.GetToken(ctx, ScopeApiAdmin, participantContextID)
 	if err != nil {
 		return fmt.Errorf("failed to get API access token: %w", err)
 	}

--- a/agent/common/issuerservice/issuer_test.go
+++ b/agent/common/issuerservice/issuer_test.go
@@ -61,7 +61,7 @@ func TestHttpApiClient_CreateHolder(t *testing.T) {
 		HttpClient:    &http.Client{},
 	}
 
-	err := client.CreateHolder(t.Context(), "did:web:test-participant", "did:web:test-participant", "test holder", nil)
+	err := client.CreateHolder(t.Context(), "test-context-id", "did:web:test-participant", "did:web:test-participant", "test holder", nil)
 	require.NoError(t, err)
 }
 
@@ -76,7 +76,7 @@ func TestHttpApiClient_CreateHolder_AuthError(t *testing.T) {
 		HttpClient:    &http.Client{},
 	}
 
-	err := client.CreateHolder(t.Context(), "did:web:test-participant", "did:web:test-participant", "test holder", nil)
+	err := client.CreateHolder(t.Context(), "test-context-id", "did:web:test-participant", "did:web:test-participant", "test holder", nil)
 	require.ErrorContains(t, err, "test error")
 }
 
@@ -102,7 +102,7 @@ func TestHttpApiClient_CreateHolder_ApiReturnsError(t *testing.T) {
 		HttpClient:    &http.Client{},
 	}
 
-	err := client.CreateHolder(t.Context(), "did:web:test-participant", "did:web:test-participant", "test holder", nil)
+	err := client.CreateHolder(t.Context(), "", "did:web:test-participant", "did:web:test-participant", "test holder", nil)
 	require.ErrorContains(t, err, "failed to create Holder")
 }
 
@@ -202,7 +202,7 @@ func TestHttpApiClient_DeleteHolder(t *testing.T) {
 		HttpClient:    &http.Client{},
 	}
 
-	err := client.DeleteHolder(t.Context(), "did:web:test-participant")
+	err := client.DeleteHolder(t.Context(), "", "did:web:test-participant")
 	require.NoError(t, err)
 }
 
@@ -227,7 +227,7 @@ func TestHttpApiClient_DeleteHolder_NotFound(t *testing.T) {
 		HttpClient:    &http.Client{},
 	}
 
-	err := client.DeleteHolder(t.Context(), "did:web:test-participant")
+	err := client.DeleteHolder(t.Context(), "", "did:web:test-participant")
 	require.ErrorContains(t, err, "received status code 404")
 }
 
@@ -252,7 +252,7 @@ func TestHttpApiClient_DeleteHolder_AuthError(t *testing.T) {
 		HttpClient:    &http.Client{},
 	}
 
-	err := client.DeleteHolder(t.Context(), "did:web:test-participant")
+	err := client.DeleteHolder(t.Context(), "", "did:web:test-participant")
 	require.ErrorContains(t, err, "received status code 401")
 }
 

--- a/agent/common/issuerservice/issuer_test.go
+++ b/agent/common/issuerservice/issuer_test.go
@@ -53,7 +53,7 @@ func TestHttpApiClient_CreateHolder(t *testing.T) {
 	defer server.Close()
 
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("test token", nil)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("test token", nil)
 	client := HttpApiClient{
 		BaseURL:       server.URL,
 		TokenProvider: tp,
@@ -68,7 +68,7 @@ func TestHttpApiClient_CreateHolder(t *testing.T) {
 func TestHttpApiClient_CreateHolder_AuthError(t *testing.T) {
 
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("", fmt.Errorf("test error"))
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("", fmt.Errorf("test error"))
 	client := HttpApiClient{
 		BaseURL:       "http://foo.bar",
 		TokenProvider: tp,
@@ -94,7 +94,7 @@ func TestHttpApiClient_CreateHolder_ApiReturnsError(t *testing.T) {
 	defer server.Close()
 
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("test token", nil)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("test token", nil)
 	client := HttpApiClient{
 		BaseURL:       server.URL,
 		TokenProvider: tp,
@@ -119,7 +119,7 @@ func TestHttpApiClient_RevokeCredential(t *testing.T) {
 	defer server.Close()
 
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("test token", nil)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("test token", nil)
 	client := HttpApiClient{
 		BaseURL:       server.URL,
 		TokenProvider: tp,
@@ -144,7 +144,7 @@ func TestHttpApiClient_RevokeCredential_ClientError(t *testing.T) {
 	defer server.Close()
 
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("test token", nil)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("test token", nil)
 	client := HttpApiClient{
 		BaseURL:       server.URL,
 		TokenProvider: tp,
@@ -169,7 +169,7 @@ func TestHttpApiClient_RevokeCredential_NotFound(t *testing.T) {
 	defer server.Close()
 
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("test token", nil)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("test token", nil)
 	client := HttpApiClient{
 		BaseURL:       server.URL,
 		TokenProvider: tp,
@@ -194,7 +194,7 @@ func TestHttpApiClient_DeleteHolder(t *testing.T) {
 	defer server.Close()
 
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("test token", nil)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("test token", nil)
 	client := HttpApiClient{
 		BaseURL:       server.URL,
 		TokenProvider: tp,
@@ -219,7 +219,7 @@ func TestHttpApiClient_DeleteHolder_NotFound(t *testing.T) {
 	defer server.Close()
 
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("test token", nil)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("test token", nil)
 	client := HttpApiClient{
 		BaseURL:       server.URL,
 		TokenProvider: tp,
@@ -244,7 +244,7 @@ func TestHttpApiClient_DeleteHolder_AuthError(t *testing.T) {
 	defer server.Close()
 
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("test token", nil)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("test token", nil)
 	client := HttpApiClient{
 		BaseURL:       server.URL,
 		TokenProvider: tp,
@@ -296,7 +296,7 @@ func TestHttpApiClient_QueryCredentialsByType(t *testing.T) {
 	defer server.Close()
 
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("test token", nil)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("test token", nil)
 	client := HttpApiClient{
 		BaseURL:       server.URL,
 		TokenProvider: tp,
@@ -313,7 +313,7 @@ func TestHttpApiClient_QueryCredentialsByType(t *testing.T) {
 
 func TestHttpApiClient_QueryCredentialsByType_AuthError(t *testing.T) {
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("", fmt.Errorf("auth error"))
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("", fmt.Errorf("auth error"))
 	client := HttpApiClient{
 		BaseURL:       "http://foo.bar",
 		TokenProvider: tp,
@@ -339,7 +339,7 @@ func TestHttpApiClient_QueryCredentialsByType_ApiReturnsError(t *testing.T) {
 	defer server.Close()
 
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("test token", nil)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("test token", nil)
 	client := HttpApiClient{
 		BaseURL:       server.URL,
 		TokenProvider: tp,
@@ -367,7 +367,7 @@ func TestHttpApiClient_QueryCredentialsByType_InvalidJson(t *testing.T) {
 	defer server.Close()
 
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("test token", nil)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("test token", nil)
 	client := HttpApiClient{
 		BaseURL:       server.URL,
 		TokenProvider: tp,

--- a/agent/edcv/activity/activity.go
+++ b/agent/edcv/activity/activity.go
@@ -45,9 +45,9 @@ type EDCVActivityProcessor struct {
 }
 
 type edcData struct {
-	ParticipantID       string `json:"cfm.participant.id" validate:"required"`
-	VaultAccessClientID string `json:"clientID.vaultAccess" validate:"required"`
-	ApiAccessClientID   string `json:"clientID.apiAccess" validate:"required"`
+	ParticipantID        string `json:"cfm.participant.id" validate:"required"`
+	VaultAccessClientID  string `json:"clientID.vaultAccess" validate:"required"`
+	ParticipantContextId string `json:"participantContextId" validate:"required"`
 	// CredentialServiceURL the URL of the credential service, i.e., the query and storage endpoints of IdentityHub
 	CredentialServiceURL string `json:"cfm.participant.credentialservice"`
 	// ProtocolServiceURL the URL of the protocol service, i.e., the DSP protocol endpoint of the control plane
@@ -87,7 +87,7 @@ func (p EDCVActivityProcessor) ProcessDeploy(ctx api.ActivityContext) api.Activi
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing EDC-V activity for orchestration %s: %w", ctx.OID(), err)}
 	}
 
-	participantContextId := data.ApiAccessClientID
+	participantContextId := data.ParticipantContextId
 	span.SetAttributes(attribute.String("cfm.participantContextId", participantContextId))
 	return p.handleDeployAction(ctx, data, participantContextId)
 }
@@ -98,7 +98,7 @@ func (p EDCVActivityProcessor) ProcessDispose(ctx api.ActivityContext) api.Activ
 	if err != nil {
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing EDC-V activity for orchestration %s: %w", ctx.OID(), err)}
 	}
-	return p.handleDisposeAction(ctx.Context(), data.ApiAccessClientID)
+	return p.handleDisposeAction(ctx.Context(), data.ParticipantContextId)
 }
 
 // handleDeployAction creates the participant context and config in the EDC control plane.
@@ -159,7 +159,7 @@ func (p EDCVActivityProcessor) handleDeployAction(ctx api.ActivityContext, data 
 	}
 	ctrl.AddEvent("Created ParticipantContextConfig in Control Plane")
 	ctrl.End()
-	p.Monitor.Infof("EDCV activity for participant '%s' (client ID = %s) completed successfully", data.ParticipantID, data.ApiAccessClientID)
+	p.Monitor.Infof("EDCV activity for participant '%s' (client ID = %s) completed successfully", data.ParticipantID, data.ParticipantContextId)
 
 	// delete the vault access secret, since it's no longer needed'
 	if err := p.VaultClient.DeleteSecret(ctx.Context(), data.VaultAccessClientID); err != nil {

--- a/agent/edcv/activity/activity_test.go
+++ b/agent/edcv/activity/activity_test.go
@@ -51,7 +51,7 @@ func validConfig(opts ...ConfigOptions) *Config {
 var processingData = map[string]any{
 	model.ParticipantIdentifier:         "participant-abc",
 	"clientID.vaultAccess":              "client-123",
-	"clientID.apiAccess":                "client-456",
+	"participantContextId":              "client-456",
 	"cfm.participant.credentialservice": "https://example.com/credentialservice",
 	"cfm.participant.protocolservice":   "https://example.com/protocolservice",
 	"publicURL":                         "http://test.example.com:1234/fizz/buzz",

--- a/agent/edcv/controlplane/controlplane.go
+++ b/agent/edcv/controlplane/controlplane.go
@@ -33,8 +33,9 @@ const (
 	ParticipantContextStateActivated   ParticipantContextState = "ACTIVATED"
 	ParticipantContextStateDeactivated ParticipantContextState = "DEACTIVATED"
 	contextConnector                                           = "https://w3id.org/edc/connector/management/v2"
-	ScopeApiWrite                                              = "write provisioner"
-	ScopeApiRead                                               = "read provisioner"
+	ScopeApiWrite                                              = "write"
+	ScopeApiRead                                               = "read"
+	ScopeApiAdmin                                              = "admin"
 )
 
 type ParticipantContextConfig struct {
@@ -96,7 +97,7 @@ func (h HttpManagementAPIClient) DeleteConfig(ctx context.Context, participantCo
 }
 
 func (h HttpManagementAPIClient) DeleteParticipantContext(ctx context.Context, participantContextID string) error {
-	accessToken, err := h.TokenProvider.GetToken(ctx, ScopeApiWrite, participantContextID)
+	accessToken, err := h.TokenProvider.GetToken(ctx, ScopeApiAdmin, participantContextID)
 	if err != nil {
 		return fmt.Errorf("failed to get API access token: %w", err)
 	}
@@ -125,7 +126,7 @@ func (h HttpManagementAPIClient) DeleteParticipantContext(ctx context.Context, p
 }
 
 func (h HttpManagementAPIClient) CreateParticipantContext(ctx context.Context, manifest ParticipantContext) error {
-	accessToken, err := h.TokenProvider.GetToken(ctx, ScopeApiWrite, manifest.ParticipantContextID)
+	accessToken, err := h.TokenProvider.GetToken(ctx, ScopeApiAdmin, manifest.ParticipantContextID)
 	if err != nil {
 		return fmt.Errorf("failed to get API access token: %w", err)
 	}
@@ -168,7 +169,7 @@ func (h HttpManagementAPIClient) CreateParticipantContext(ctx context.Context, m
 
 func (h HttpManagementAPIClient) CreateConfig(ctx context.Context, participantContextID string, config ParticipantContextConfig) error {
 
-	accessToken, err := h.TokenProvider.GetToken(ctx, ScopeApiWrite, participantContextID)
+	accessToken, err := h.TokenProvider.GetToken(ctx, ScopeApiAdmin, participantContextID)
 	if err != nil {
 		return fmt.Errorf("failed to get API access token: %w", err)
 	}

--- a/agent/edcv/controlplane/controlplane.go
+++ b/agent/edcv/controlplane/controlplane.go
@@ -33,8 +33,8 @@ const (
 	ParticipantContextStateActivated   ParticipantContextState = "ACTIVATED"
 	ParticipantContextStateDeactivated ParticipantContextState = "DEACTIVATED"
 	contextConnector                                           = "https://w3id.org/edc/connector/management/v2"
-	ScopeApiWrite                                              = "management-api:write"
-	ScopeApiRead                                               = "management-api:read"
+	ScopeApiWrite                                              = "write provisioner"
+	ScopeApiRead                                               = "read provisioner"
 )
 
 type ParticipantContextConfig struct {

--- a/agent/edcv/controlplane/controlplane.go
+++ b/agent/edcv/controlplane/controlplane.go
@@ -33,6 +33,8 @@ const (
 	ParticipantContextStateActivated   ParticipantContextState = "ACTIVATED"
 	ParticipantContextStateDeactivated ParticipantContextState = "DEACTIVATED"
 	contextConnector                                           = "https://w3id.org/edc/connector/management/v2"
+	ScopeApiWrite                                              = "management-api:write"
+	ScopeApiRead                                               = "management-api:read"
 )
 
 type ParticipantContextConfig struct {
@@ -94,7 +96,7 @@ func (h HttpManagementAPIClient) DeleteConfig(ctx context.Context, participantCo
 }
 
 func (h HttpManagementAPIClient) DeleteParticipantContext(ctx context.Context, participantContextID string) error {
-	accessToken, err := h.TokenProvider.GetToken(ctx)
+	accessToken, err := h.TokenProvider.GetToken(ctx, ScopeApiWrite, participantContextID)
 	if err != nil {
 		return fmt.Errorf("failed to get API access token: %w", err)
 	}
@@ -123,7 +125,7 @@ func (h HttpManagementAPIClient) DeleteParticipantContext(ctx context.Context, p
 }
 
 func (h HttpManagementAPIClient) CreateParticipantContext(ctx context.Context, manifest ParticipantContext) error {
-	accessToken, err := h.TokenProvider.GetToken(ctx)
+	accessToken, err := h.TokenProvider.GetToken(ctx, ScopeApiWrite, manifest.ParticipantContextID)
 	if err != nil {
 		return fmt.Errorf("failed to get API access token: %w", err)
 	}
@@ -165,7 +167,8 @@ func (h HttpManagementAPIClient) CreateParticipantContext(ctx context.Context, m
 }
 
 func (h HttpManagementAPIClient) CreateConfig(ctx context.Context, participantContextID string, config ParticipantContextConfig) error {
-	accessToken, err := h.TokenProvider.GetToken(ctx)
+
+	accessToken, err := h.TokenProvider.GetToken(ctx, ScopeApiWrite, participantContextID)
 	if err != nil {
 		return fmt.Errorf("failed to get API access token: %w", err)
 	}

--- a/agent/edcv/controlplane/controlplane_test.go
+++ b/agent/edcv/controlplane/controlplane_test.go
@@ -145,7 +145,7 @@ func TestCreateParticipant(t *testing.T) {
 	defer server.Close()
 
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("token", nil)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("token", nil)
 	client := HttpManagementAPIClient{
 		BaseURL:       server.URL,
 		TokenProvider: tp,
@@ -165,7 +165,7 @@ func TestCreateParticipant(t *testing.T) {
 
 func TestCreateParticipant_AuthError(t *testing.T) {
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("", fmt.Errorf("test error"))
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("", fmt.Errorf("test error"))
 	client := HttpManagementAPIClient{
 		BaseURL:       "http://foo.bar",
 		TokenProvider: tp,
@@ -189,7 +189,7 @@ func TestCreateParticipant_BadRequest(t *testing.T) {
 	}))
 	defer server.Close()
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("test token", nil)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("test token", nil)
 	client := HttpManagementAPIClient{
 		BaseURL:       server.URL,
 		TokenProvider: tp,
@@ -213,7 +213,7 @@ func TestCreateParticipant_Conflict(t *testing.T) {
 	}))
 	defer server.Close()
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("test token", nil)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("test token", nil)
 	client := HttpManagementAPIClient{
 		BaseURL:       server.URL,
 		TokenProvider: tp,
@@ -250,7 +250,7 @@ func TestCreateParticipantConfig(t *testing.T) {
 	defer server.Close()
 
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("token", nil)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("token", nil)
 	client := HttpManagementAPIClient{
 		BaseURL:       server.URL,
 		TokenProvider: tp,
@@ -269,7 +269,7 @@ func TestCreateParticipantConfig(t *testing.T) {
 
 func TestCreateParticipantConfig_AuthError(t *testing.T) {
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("", fmt.Errorf("test error"))
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("", fmt.Errorf("test error"))
 	client := HttpManagementAPIClient{
 		BaseURL:       "http://foo.bar",
 		TokenProvider: tp,
@@ -292,7 +292,7 @@ func TestCreateParticipantConfig_BadRequest(t *testing.T) {
 	}))
 	defer server.Close()
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("test token", nil)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("test token", nil)
 	client := HttpManagementAPIClient{
 		BaseURL:       server.URL,
 		TokenProvider: tp,
@@ -315,7 +315,7 @@ func TestCreateParticipantConfig_Conflict(t *testing.T) {
 	}))
 	defer server.Close()
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("test token", nil)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("test token", nil)
 	client := HttpManagementAPIClient{
 		BaseURL:       server.URL,
 		TokenProvider: tp,
@@ -342,7 +342,7 @@ func TestDeleteParticipant(t *testing.T) {
 	defer server.Close()
 
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("token", nil)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("token", nil)
 	client := HttpManagementAPIClient{
 		BaseURL:       server.URL,
 		TokenProvider: tp,
@@ -355,7 +355,7 @@ func TestDeleteParticipant(t *testing.T) {
 
 func TestDeleteParticipant_AuthError(t *testing.T) {
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("", fmt.Errorf("test error"))
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("", fmt.Errorf("test error"))
 	client := HttpManagementAPIClient{
 		BaseURL:       "http://foo.bar",
 		TokenProvider: tp,
@@ -372,7 +372,7 @@ func TestDeleteParticipant_NotFound(t *testing.T) {
 	}))
 	defer server.Close()
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("test token", nil)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("test token", nil)
 	client := HttpManagementAPIClient{
 		BaseURL:       server.URL,
 		TokenProvider: tp,
@@ -389,7 +389,7 @@ func TestDeleteParticipant_ServerError(t *testing.T) {
 	}))
 	defer server.Close()
 	tp := mocks.NewMockTokenProvider(t)
-	tp.On("GetToken", mock.Anything).Return("test token", nil)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("test token", nil)
 	client := HttpManagementAPIClient{
 		BaseURL:       server.URL,
 		TokenProvider: tp,

--- a/agent/edcv/launcher/launcher.go
+++ b/agent/edcv/launcher/launcher.go
@@ -66,14 +66,6 @@ func LaunchAndWaitSignal(shutdown <-chan struct{}) {
 				panic(err)
 			}
 
-			//provider := oauth2.NewTokenProvider(
-			//	oauth2.Oauth2Params{
-			//		ClientID:     clientID,
-			//		ClientSecret: clientSecret,
-			//		TokenURL:     tokenURL,
-			//		GrantType:    oauth2.ClientCredentials,
-			//	}, &httpClient)
-
 			provider := tokenexchange.NewTokenExchangeProvider(ctx.Config.GetString(tokenFilePathKey),
 				tokenexchange.WithTokenExchangeUrl(ctx.Config.GetString(tokenExchangeURLKey)),
 				tokenexchange.WithTokenExchangeAudience(ctx.Config.GetString(audienceKey)),

--- a/agent/edcv/launcher/launcher.go
+++ b/agent/edcv/launcher/launcher.go
@@ -20,9 +20,9 @@ import (
 	"github.com/eclipse-cfm/cfm/assembly/httpclient"
 	"github.com/eclipse-cfm/cfm/assembly/serviceapi"
 	"github.com/eclipse-cfm/cfm/assembly/vault"
-	"github.com/eclipse-cfm/cfm/common/oauth2"
 	"github.com/eclipse-cfm/cfm/common/runtime"
 	"github.com/eclipse-cfm/cfm/common/system"
+	"github.com/eclipse-cfm/cfm/common/tokenexchange"
 	"github.com/eclipse-cfm/cfm/pmanager/api"
 	"github.com/eclipse-cfm/cfm/pmanager/natsagent"
 )
@@ -35,6 +35,9 @@ const (
 	tokenURLKey          = "keycloak.tokenUrl"
 	identityHubStsURLKey = "identityhub.sts.url"
 	controlPlaneURLKey   = "controlplane.url"
+	tokenExchangeURLKey  = "tokenexchange.url"
+	tokenFilePathKey     = "tokenexchange.tokenFilePath"
+	audienceKey          = "tokenexchange.audience"
 )
 
 func LaunchAndWaitSignal(shutdown <-chan struct{}) {
@@ -63,13 +66,18 @@ func LaunchAndWaitSignal(shutdown <-chan struct{}) {
 				panic(err)
 			}
 
-			provider := oauth2.NewTokenProvider(
-				oauth2.Oauth2Params{
-					ClientID:     clientID,
-					ClientSecret: clientSecret,
-					TokenURL:     tokenURL,
-					GrantType:    oauth2.ClientCredentials,
-				}, &httpClient)
+			//provider := oauth2.NewTokenProvider(
+			//	oauth2.Oauth2Params{
+			//		ClientID:     clientID,
+			//		ClientSecret: clientSecret,
+			//		TokenURL:     tokenURL,
+			//		GrantType:    oauth2.ClientCredentials,
+			//	}, &httpClient)
+
+			provider := tokenexchange.NewTokenExchangeProvider(ctx.Config.GetString(tokenFilePathKey),
+				tokenexchange.WithTokenExchangeUrl(ctx.Config.GetString(tokenExchangeURLKey)),
+				tokenexchange.WithTokenExchangeAudience(ctx.Config.GetString(audienceKey)),
+				tokenexchange.WithHttpClient(&httpClient))
 			return activity.NewProcessor(&activity.Config{
 				VaultClient: vaultClient,
 				LogMonitor:  ctx.Monitor,

--- a/agent/ih/activity/activity.go
+++ b/agent/ih/activity/activity.go
@@ -53,7 +53,7 @@ type IdentityHubActivityProcessor struct {
 type ihData struct {
 	ParticipantID        string `json:"cfm.participant.id" validate:"required"`
 	VaultAccessClientID  string `json:"clientID.vaultAccess" validate:"required"`
-	ApiAccessClientID    string `json:"clientID.apiAccess" validate:"required"`
+	ParticipantContextId string `json:"participantContextId" validate:"required"`
 	CredentialServiceURL string `json:"cfm.participant.credentialservice"`
 	ProtocolServiceURL   string `json:"cfm.participant.protocolservice"`
 	DataServiceURL       string `json:"cfm.participant.dataservice"`
@@ -96,7 +96,7 @@ func (p IdentityHubActivityProcessor) ProcessDeploy(ctx api.ActivityContext) api
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing IH activity for orchestration %s: %w", ctx.OID(), err)}
 	}
 
-	participantContextId := data.ApiAccessClientID
+	participantContextId := data.ParticipantContextId
 	span.SetAttributes(attribute.String("cfm.participantContextId", participantContextId))
 	return p.handleDeployAction(ctx, data, participantContextId)
 }
@@ -106,7 +106,7 @@ func (p IdentityHubActivityProcessor) ProcessDispose(ctx api.ActivityContext) ap
 	if err := ctx.ReadValues(&data); err != nil {
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing IH activity for orchestration %s: %w", ctx.OID(), err)}
 	}
-	return p.handleDisposeAction(ctx.Context(), data.ApiAccessClientID)
+	return p.handleDisposeAction(ctx.Context(), data.ParticipantContextId)
 }
 
 // handleDeployAction creates the participant context in IdentityHub and stores the returned STSClientID

--- a/agent/ih/activity/activity_test.go
+++ b/agent/ih/activity/activity_test.go
@@ -54,7 +54,7 @@ func validConfig(opts ...ConfigOption) *Config {
 var processingData = map[string]any{
 	model.ParticipantIdentifier:         "did:web:participant-abc",
 	"clientID.vaultAccess":              "client-123",
-	"clientID.apiAccess":                "client-456",
+	"participantContextId":              "client-456",
 	"cfm.participant.credentialservice": "https://example.com/credentialservice",
 	"cfm.participant.protocolservice":   "https://example.com/protocolservice",
 	"cfm.participant.dataservice":       "https://example.com/dataservice",

--- a/agent/ih/launcher/launcher.go
+++ b/agent/ih/launcher/launcher.go
@@ -20,9 +20,9 @@ import (
 	"github.com/eclipse-cfm/cfm/assembly/httpclient"
 	"github.com/eclipse-cfm/cfm/assembly/serviceapi"
 	"github.com/eclipse-cfm/cfm/assembly/vault"
-	"github.com/eclipse-cfm/cfm/common/oauth2"
 	"github.com/eclipse-cfm/cfm/common/runtime"
 	"github.com/eclipse-cfm/cfm/common/system"
+	"github.com/eclipse-cfm/cfm/common/tokenexchange"
 	"github.com/eclipse-cfm/cfm/pmanager/api"
 	"github.com/eclipse-cfm/cfm/pmanager/natsagent"
 )
@@ -37,6 +37,9 @@ const (
 	identityHubCredentialServiceURLKey = "identityhub.cs.url"
 	controlPlaneProtocolURLKey         = "controlplane.protocol.url"
 	controlPlaneDataServiceURLKey      = "controlplane.dataservice.url"
+	tokenExchangeURLKey                = "tokenexchange.url"
+	tokenFilePathKey                   = "tokenexchange.tokenFilePath"
+	audienceKey                        = "tokenexchange.audience"
 )
 
 func LaunchAndWaitSignal(shutdown <-chan struct{}) {
@@ -67,13 +70,10 @@ func LaunchAndWaitSignal(shutdown <-chan struct{}) {
 				panic(err)
 			}
 
-			provider := oauth2.NewTokenProvider(
-				oauth2.Oauth2Params{
-					ClientID:     clientID,
-					ClientSecret: clientSecret,
-					TokenURL:     tokenURL,
-					GrantType:    oauth2.ClientCredentials,
-				}, &httpClient)
+			provider := tokenexchange.NewTokenExchangeProvider(ctx.Config.GetString(tokenFilePathKey),
+				tokenexchange.WithTokenExchangeUrl(ctx.Config.GetString(tokenExchangeURLKey)),
+				tokenexchange.WithTokenExchangeAudience(ctx.Config.GetString(audienceKey)),
+				tokenexchange.WithHttpClient(&httpClient))
 
 			return activity.NewProcessor(&activity.Config{
 				VaultClient: vaultClient,

--- a/agent/jwtlet-agent/Makefile
+++ b/agent/jwtlet-agent/Makefile
@@ -1,0 +1,48 @@
+.PHONY: build test clean run server
+
+# Binary name
+SERVER_BINARY=jwtletagent
+
+# Build settings
+BUILD_DIR=bin
+SERVER_PATH=./cmd/server/main.go
+
+DOCKER_TAG=latest
+
+# Environment variables
+export CGO_ENABLED=0
+
+# Install development tools
+install-tools:
+
+# Build the application
+build: build-server
+
+# Build the server
+build-server:
+	go build -o $(BUILD_DIR)/$(SERVER_BINARY) $(SERVER_PATH)
+
+# Run tests
+test:
+	$(TEST_CMD)
+
+# Clean build artifacts
+clean:
+	rm -rf $(BUILD_DIR)
+	go clean
+
+# Run the server in development mode
+dev-server: build-server
+	./$(BUILD_DIR)/$(SERVER_BINARY)
+
+# Run the server in production mode
+server: build-server
+	./$(BUILD_DIR)/$(SERVER_BINARY)
+
+# Build for multiple platforms
+build-all:
+	# Server binaries
+	GOOS=linux GOARCH=amd64 go build -o $(BUILD_DIR)/$(SERVER_BINARY)-linux-amd64 $(SERVER_PATH)
+	GOOS=darwin GOARCH=amd64 go build -o $(BUILD_DIR)/$(SERVER_BINARY)-darwin-amd64 $(SERVER_PATH)
+	GOOS=darwin GOARCH=arm64 go build -o $(BUILD_DIR)/$(SERVER_BINARY)-darwin-arm64 $(SERVER_PATH)
+	GOOS=windows GOARCH=amd64 go build -o $(BUILD_DIR)/$(SERVER_BINARY)-windows-amd64.exe $(SERVER_PATH)

--- a/agent/jwtlet-agent/activity/activity.go
+++ b/agent/jwtlet-agent/activity/activity.go
@@ -32,6 +32,14 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+const (
+	participantContextIDKey = "participantContextId"
+	jsonContentType         = "application/json"
+	contentTypeHeader       = "Content-Type"
+	authHeader              = "Authorization"
+	clientIdentifier        = "system:serviceaccount:edc-v:cfm-agents"
+)
+
 type TokenExchangeActivityProcessor struct {
 	api.BaseActivityProcessor
 	Monitor            system.LogMonitor
@@ -94,7 +102,7 @@ func (p TokenExchangeActivityProcessor) ProcessDeploy(ctx api.ActivityContext) a
 
 	// step 1: create resource mapping
 	rm := resourceMapping{
-		ClientIdentifier:   "system:serviceaccount:edc-v:cfm-agents",
+		ClientIdentifier:   clientIdentifier,
 		ParticipantContext: participantContextID,
 		Scopes:             []string{"read", "write"},
 		Audiences:          []string{p.Audience},
@@ -141,6 +149,23 @@ func (p TokenExchangeActivityProcessor) ProcessDeploy(ctx api.ActivityContext) a
 	}
 	p.Monitor.Debugf("token exchange successful. claims: %s", claims)
 
+	ctx.SetOutputValue(participantContextIDKey, participantContextID)
+
+	return api.ActivityResult{Result: api.ActivityResultComplete}
+}
+
+func (p TokenExchangeActivityProcessor) ProcessDispose(ctx api.ActivityContext) api.ActivityResult {
+	participantContextID, ok := ctx.Value(participantContextIDKey)
+	if !ok {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing token exchange dispose for orchestration %s: participant context ID not found in context", ctx.OID())}
+	}
+	err := p.delete(ctx.Context(), fmt.Sprintf("/api/v1/mappings/%s/%s", clientIdentifier, participantContextID))
+	if err != nil {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error deleting resource mapping: %w", err)}
+	}
+
+	// we do NOT delete the scope mappings, because they only exist once for all participants
+
 	return api.ActivityResult{Result: api.ActivityResultComplete}
 }
 
@@ -159,19 +184,48 @@ func (p TokenExchangeActivityProcessor) post(ctx context.Context, url string, bo
 	if err != nil {
 		return fmt.Errorf("error creating request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+string(tokenBytes))
+	req.Header.Set(contentTypeHeader, jsonContentType)
+	req.Header.Set(authHeader, "Bearer "+string(tokenBytes))
 	resp, err := p.HttpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("error sending request: %w", err)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusCreated {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("request '%s %s' failed with status %d", req.Method, req.URL.String(), resp.StatusCode)
 	}
 
 	return nil
+}
+
+func (p TokenExchangeActivityProcessor) delete(ctx context.Context, url string) error {
+	// read workload token
+	tokenBytes, err := os.ReadFile(p.TokenFilePath)
+	if err != nil {
+		return fmt.Errorf("error reading token file from %s: %w", p.TokenFilePath, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, p.ManagementBasePath+url, nil)
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+	req.Header.Set(authHeader, "Bearer "+string(tokenBytes))
+	resp, err := p.HttpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("error sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("request '%s %s' failed with status %d", req.Method, req.URL.String(), resp.StatusCode)
+	}
+
+	return nil
+}
+
+func generateClientID() string {
+	return strings.ReplaceAll(uuid.New().String(), "-", "")
 }
 
 // decodeJWTClaims base64-decodes the payload section of a JWT and returns it as a raw JSON string.
@@ -185,16 +239,4 @@ func decodeJWTClaims(jwtToken string) (string, error) {
 		return "", fmt.Errorf("error decoding JWT payload: %w", err)
 	}
 	return string(payload), nil
-}
-
-func (p TokenExchangeActivityProcessor) ProcessDispose(ctx api.ActivityContext) api.ActivityResult {
-	var data tokenExchangeData
-	if err := ctx.ReadValues(&data); err != nil {
-		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing token exchange dispose for orchestration %s: %w", ctx.OID(), err)}
-	}
-	p.Monitor.Debugf("Token exchange dispose for participant '%s' completed", data.ParticipantID)
-	return api.ActivityResult{Result: api.ActivityResultComplete}
-}
-func generateClientID() string {
-	return strings.ReplaceAll(uuid.New().String(), "-", "")
 }

--- a/agent/jwtlet-agent/activity/activity.go
+++ b/agent/jwtlet-agent/activity/activity.go
@@ -149,6 +149,8 @@ func (p TokenExchangeActivityProcessor) ProcessDeploy(ctx api.ActivityContext) a
 	}
 	p.Monitor.Debugf("token exchange successful. claims: %s", claims)
 
+	// set both - for further processing in other agents and for the output
+	ctx.SetValue(participantContextIDKey, participantContextID)
 	ctx.SetOutputValue(participantContextIDKey, participantContextID)
 
 	return api.ActivityResult{Result: api.ActivityResultComplete}

--- a/agent/jwtlet-agent/activity/activity.go
+++ b/agent/jwtlet-agent/activity/activity.go
@@ -104,7 +104,7 @@ func (p TokenExchangeActivityProcessor) ProcessDeploy(ctx api.ActivityContext) a
 	rm := resourceMapping{
 		ClientIdentifier:   clientIdentifier,
 		ParticipantContext: participantContextID,
-		Scopes:             []string{"read", "write", "provisioner", "admin", "participant"},
+		Scopes:             []string{"read", "write", "admin"},
 		Audiences:          []string{p.Audience},
 	}
 	p.Monitor.Debugf("Creating resource mapping for participant context: %s", participantContextID)
@@ -113,19 +113,7 @@ func (p TokenExchangeActivityProcessor) ProcessDeploy(ctx api.ActivityContext) a
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error creating resource mapping: %w", err)}
 	}
 
-	// step 2: create "participant" scope mapping
-	sm4 := scopeMapping{
-		Scope: "participant",
-		Claims: map[string]string{
-			"role": "participant",
-		},
-	}
-	p.Monitor.Debugf("Creating participant scope mapping for participant context: %s", participantContextID)
-	if err := p.post(ctx.Context(), "/api/v1/scopes", sm4); err != nil {
-		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error creating scope mapping: %w", err)}
-	}
-
-	// step 3: test token exchange
+	// step 2: test token exchange
 	p.Monitor.Debugf("testing token exchange for participant context: %s", participantContextID)
 	scopedToken, err := p.TokenProvider.GetToken(ctx.Context(), "read write", participantContextID)
 	if err != nil {

--- a/agent/jwtlet-agent/activity/activity.go
+++ b/agent/jwtlet-agent/activity/activity.go
@@ -1,0 +1,200 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package activity
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/eclipse-cfm/cfm/common/system"
+	"github.com/eclipse-cfm/cfm/common/token"
+	"github.com/eclipse-cfm/cfm/pmanager/api"
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type TokenExchangeActivityProcessor struct {
+	api.BaseActivityProcessor
+	Monitor            system.LogMonitor
+	TokenProvider      token.TokenProvider
+	tracer             trace.Tracer
+	HttpClient         *http.Client
+	TokenFilePath      string
+	Audience           string
+	ManagementBasePath string
+}
+
+type tokenExchangeData struct {
+	ParticipantID string `json:"cfm.participant.id" validate:"required"`
+}
+
+type resourceMapping struct {
+	ClientIdentifier   string   `json:"clientIdentifier" validate:"required"`
+	ParticipantContext string   `json:"participantContext" validate:"required"`
+	Scopes             []string `json:"scopes" validate:"required"`
+	Audiences          []string `json:"audiences"`
+}
+
+type scopeMapping struct {
+	Scope  string            `json:"scope" validate:"required"`
+	Claims map[string]string `json:"claims"`
+}
+
+type Config struct {
+	system.LogMonitor
+	token.TokenProvider
+	HttpClient         *http.Client
+	ManagementBasePath string
+	TokenFilePath      string
+	Audience           string
+}
+
+func NewProcessor(config *Config) *TokenExchangeActivityProcessor {
+	return &TokenExchangeActivityProcessor{
+		Monitor:            config.LogMonitor,
+		TokenProvider:      config.TokenProvider,
+		HttpClient:         config.HttpClient,
+		tracer:             otel.GetTracerProvider().Tracer("cfm.agent.test"),
+		ManagementBasePath: config.ManagementBasePath,
+		TokenFilePath:      config.TokenFilePath,
+		Audience:           config.Audience,
+	}
+}
+
+func (p TokenExchangeActivityProcessor) ProcessDeploy(ctx api.ActivityContext) api.ActivityResult {
+
+	var data tokenExchangeData
+	if err := ctx.ReadValues(&data); err != nil {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing token exchange deploy for orchestration %s: %w", ctx.OID(), err)}
+	}
+
+	participantContextID := generateClientID()
+
+	_, span := p.tracer.Start(ctx.Context(), "cfm.agent.jwtlet.token-setup", trace.WithSpanKind(trace.SpanKindClient))
+	defer span.End()
+
+	// step 1: create resource mapping
+	rm := resourceMapping{
+		ClientIdentifier:   "system:serviceaccount:edc-v:cfm-agents",
+		ParticipantContext: participantContextID,
+		Scopes:             []string{"read", "write"},
+		Audiences:          []string{p.Audience},
+	}
+	p.Monitor.Debugf("Creating resource mapping for participant context: %s", participantContextID)
+	err := p.post(ctx.Context(), "/api/v1/mappings", rm)
+	if err != nil {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error creating resource mapping: %w", err)}
+	}
+
+	// step 2: create "read" scope mapping
+	sm1 := scopeMapping{
+		Scope: "read",
+		Claims: map[string]string{
+			"scope": "identity-api:read management-api:read issuer-admin-api:read",
+		},
+	}
+	p.Monitor.Debugf("Creating read scope mapping for participant context: %s", participantContextID)
+	if err := p.post(ctx.Context(), "/api/v1/scopes", sm1); err != nil {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error creating scope mapping: %w", err)}
+	}
+
+	// step 3: create "write" scope mapping
+	sm2 := scopeMapping{
+		Scope: "write",
+		Claims: map[string]string{
+			"scope": "identity-api:write management-api:write issuer-admin-api:write",
+		},
+	}
+	p.Monitor.Debugf("Creating write scope mapping for participant context: %s", participantContextID)
+	if err := p.post(ctx.Context(), "/api/v1/scopes", sm2); err != nil {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error creating scope mapping: %w", err)}
+	}
+
+	// step 4: test token exchange
+	p.Monitor.Debugf("testing token exchange for participant context: %s", participantContextID)
+	scopedToken, err := p.TokenProvider.GetToken(ctx.Context(), "read write", participantContextID)
+	if err != nil {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("testing token exchange failed: error getting scoped token: %w", err)}
+	}
+	claims, err := decodeJWTClaims(scopedToken)
+	if err != nil {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("testing token exchange failed: error decoding JWT claims: %w", err)}
+	}
+	p.Monitor.Debugf("token exchange successful. claims: %s", claims)
+
+	return api.ActivityResult{Result: api.ActivityResultComplete}
+}
+
+func (p TokenExchangeActivityProcessor) post(ctx context.Context, url string, body any) error {
+	// read workload token
+	tokenBytes, err := os.ReadFile(p.TokenFilePath)
+	if err != nil {
+		return fmt.Errorf("error reading token file from %s: %w", p.TokenFilePath, err)
+	}
+
+	bodyJson, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("error marshalling body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.ManagementBasePath+url, bytes.NewReader(bodyJson))
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+string(tokenBytes))
+	resp, err := p.HttpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("error sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("request '%s %s' failed with status %d", req.Method, req.URL.String(), resp.StatusCode)
+	}
+
+	return nil
+}
+
+// decodeJWTClaims base64-decodes the payload section of a JWT and returns it as a raw JSON string.
+func decodeJWTClaims(jwtToken string) (string, error) {
+	parts := strings.SplitN(jwtToken, ".", 3)
+	if len(parts) != 3 {
+		return "", fmt.Errorf("invalid JWT format")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("error decoding JWT payload: %w", err)
+	}
+	return string(payload), nil
+}
+
+func (p TokenExchangeActivityProcessor) ProcessDispose(ctx api.ActivityContext) api.ActivityResult {
+	var data tokenExchangeData
+	if err := ctx.ReadValues(&data); err != nil {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing token exchange dispose for orchestration %s: %w", ctx.OID(), err)}
+	}
+	p.Monitor.Debugf("Token exchange dispose for participant '%s' completed", data.ParticipantID)
+	return api.ActivityResult{Result: api.ActivityResultComplete}
+}
+func generateClientID() string {
+	return strings.ReplaceAll(uuid.New().String(), "-", "")
+}

--- a/agent/jwtlet-agent/activity/activity.go
+++ b/agent/jwtlet-agent/activity/activity.go
@@ -104,7 +104,7 @@ func (p TokenExchangeActivityProcessor) ProcessDeploy(ctx api.ActivityContext) a
 	rm := resourceMapping{
 		ClientIdentifier:   clientIdentifier,
 		ParticipantContext: participantContextID,
-		Scopes:             []string{"read", "write"},
+		Scopes:             []string{"read", "write", "provisioner", "admin", "participant"},
 		Audiences:          []string{p.Audience},
 	}
 	p.Monitor.Debugf("Creating resource mapping for participant context: %s", participantContextID)
@@ -113,31 +113,19 @@ func (p TokenExchangeActivityProcessor) ProcessDeploy(ctx api.ActivityContext) a
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error creating resource mapping: %w", err)}
 	}
 
-	// step 2: create "read" scope mapping
-	sm1 := scopeMapping{
-		Scope: "read",
+	// step 2: create "participant" scope mapping
+	sm4 := scopeMapping{
+		Scope: "participant",
 		Claims: map[string]string{
-			"scope": "identity-api:read management-api:read issuer-admin-api:read",
+			"role": "participant",
 		},
 	}
-	p.Monitor.Debugf("Creating read scope mapping for participant context: %s", participantContextID)
-	if err := p.post(ctx.Context(), "/api/v1/scopes", sm1); err != nil {
+	p.Monitor.Debugf("Creating participant scope mapping for participant context: %s", participantContextID)
+	if err := p.post(ctx.Context(), "/api/v1/scopes", sm4); err != nil {
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error creating scope mapping: %w", err)}
 	}
 
-	// step 3: create "write" scope mapping
-	sm2 := scopeMapping{
-		Scope: "write",
-		Claims: map[string]string{
-			"scope": "identity-api:write management-api:write issuer-admin-api:write",
-		},
-	}
-	p.Monitor.Debugf("Creating write scope mapping for participant context: %s", participantContextID)
-	if err := p.post(ctx.Context(), "/api/v1/scopes", sm2); err != nil {
-		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error creating scope mapping: %w", err)}
-	}
-
-	// step 4: test token exchange
+	// step 3: test token exchange
 	p.Monitor.Debugf("testing token exchange for participant context: %s", participantContextID)
 	scopedToken, err := p.TokenProvider.GetToken(ctx.Context(), "read write", participantContextID)
 	if err != nil {

--- a/agent/jwtlet-agent/cmd/server/main.go
+++ b/agent/jwtlet-agent/cmd/server/main.go
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package main
+
+import (
+	"github.com/eclipse-cfm/cfm/agent/jwtlet-agent/launcher"
+	"github.com/eclipse-cfm/cfm/common/runtime"
+)
+
+func main() {
+	launcher.LaunchAndWaitSignal(runtime.CreateSignalShutdownChan())
+}

--- a/agent/jwtlet-agent/launcher/launcher.go
+++ b/agent/jwtlet-agent/launcher/launcher.go
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package launcher
+
+import (
+	"net/http"
+
+	"github.com/eclipse-cfm/cfm/agent/jwtlet-agent/activity"
+	"github.com/eclipse-cfm/cfm/assembly/httpclient"
+	"github.com/eclipse-cfm/cfm/assembly/serviceapi"
+	"github.com/eclipse-cfm/cfm/common/runtime"
+	"github.com/eclipse-cfm/cfm/common/system"
+	"github.com/eclipse-cfm/cfm/common/tokenexchange"
+	"github.com/eclipse-cfm/cfm/pmanager/api"
+	"github.com/eclipse-cfm/cfm/pmanager/natsagent"
+)
+
+const (
+	ActivityType        = "jwtlet-activity"
+	tokenExchangeURLKey = "tokenexchange.url"
+	managementUrlKey    = "management.url"
+	tokenFilePathKey    = "tokenexchange.tokenFilePath"
+	audienceKey         = "tokenexchange.audience"
+)
+
+func LaunchAndWaitSignal(shutdown <-chan struct{}) {
+	config := natsagent.LauncherConfig{
+		AgentName:    "Jwtlet Agent",
+		ServiceName:  "cfm.agent.jwtlet",
+		ConfigPrefix: "jwtletagent",
+		ActivityType: ActivityType,
+		AssemblyProvider: func() []system.ServiceAssembly {
+			return []system.ServiceAssembly{
+				&httpclient.HttpClientServiceAssembly{},
+			}
+		},
+		NewProcessor: func(ctx *natsagent.AgentContext) api.ActivityProcessor {
+			httpClient := ctx.Registry.Resolve(serviceapi.HttpClientKey).(http.Client)
+			tokenExchangeURL := ctx.Config.GetString(tokenExchangeURLKey)
+			tokenFilePath := ctx.Config.GetString(tokenFilePathKey)
+			audience := ctx.Config.GetString(audienceKey)
+			managementBasePath := ctx.Config.GetString(managementUrlKey)
+
+			if err := runtime.CheckRequiredParams(tokenExchangeURLKey, tokenExchangeURL, tokenFilePathKey, tokenFilePath, managementUrlKey, managementBasePath); err != nil {
+				panic(err)
+			}
+
+			provider := tokenexchange.NewTokenExchangeProvider(
+				tokenFilePath,
+				tokenexchange.WithTokenExchangeUrl(tokenExchangeURL),
+				tokenexchange.WithTokenExchangeAudience(audience),
+				tokenexchange.WithHttpClient(&httpClient),
+			)
+
+			return activity.NewProcessor(&activity.Config{
+				LogMonitor:         ctx.Monitor,
+				TokenProvider:      provider,
+				HttpClient:         &httpClient,
+				TokenFilePath:      tokenFilePath,
+				Audience:           audience,
+				ManagementBasePath: managementBasePath,
+			})
+		},
+	}
+	natsagent.LaunchAgent(shutdown, config)
+}

--- a/agent/keycloak/activity/activity.go
+++ b/agent/keycloak/activity/activity.go
@@ -38,7 +38,6 @@ const (
 	authHeader              = "Authorization"
 	clientUrl               = "%s/admin/realms/%s/clients"
 	vaultAccessClientIDKey  = "clientID.vaultAccess"
-	apiAccessClientIDKey    = "clientID.apiAccess"
 	participantContextIDKey = "participantContextId"
 	tracerName              = "cfm.agent.keycloak"
 )
@@ -103,27 +102,9 @@ func WithEnabled(enabled bool) KeycloakClientDataOption {
 	}
 }
 
-func WithPublicClient(public bool) KeycloakClientDataOption {
-	return func(c *KeycloakClientData) {
-		c.PublicClient = public
-	}
-}
-
-func WithProtocolMappers(mappers []map[string]any) KeycloakClientDataOption {
-	return func(c *KeycloakClientData) {
-		c.ProtocolMappers = mappers
-	}
-}
-
 func WithClientID(clientID string) KeycloakClientDataOption {
 	return func(c *KeycloakClientData) {
 		c.ClientId = clientID
-	}
-}
-
-func WithClientSecret(secret string) KeycloakClientDataOption {
-	return func(c *KeycloakClientData) {
-		c.Secret = secret
 	}
 }
 
@@ -209,29 +190,15 @@ func (p KeyCloakActivityProcessor) ProcessDeploy(ctx api.ActivityContext) api.Ac
 	_, span := otel.GetTracerProvider().Tracer(tracerName).Start(ctx.Context(), "agent.kcagent.deploy")
 	defer span.End()
 
-	clientIDSlug := generateClientID()
-
-	// create Keycloak client for API access
-	participantContextID := clientIDSlug
-
-	apiClient, err := newKeycloakClientData(participantContextID, WithClientID(participantContextID), WithName("API Access Client"), WithDescription("Client for accessing the VPA's Administration APIs"), WithEnabled(true))
-	if err != nil {
-		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: err}
+	pcId, ok := ctx.Value(participantContextIDKey)
+	if !ok {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("participant context ID not found in activity context")}
 	}
-	apiClientResult := p.provisionConfidentialClient(apiClient, ctx)
-	span.AddEvent("API client created")
-	p.monitor.Debugf("created API Access client: %s", apiClient.ClientId)
-	ctx.SetValue(apiAccessClientIDKey, apiClient.ClientId)
-	ctx.SetOutputValue(participantContextIDKey, participantContextID)
-	span.SetAttributes(attribute.String("api.client.id", apiClient.ClientId), attribute.String(participantContextIDKey, participantContextID))
 
-	if apiClientResult.Result != api.ActivityResultComplete {
-		p.monitor.Warnw("Provisioning API Access client not complete. Result was %s, error: %s", apiClientResult.Result, apiClientResult.Error)
-		return apiClientResult
-	}
+	participantContextID := pcId.(string)
 
 	// create a Vault access client in Keycloak
-	vaultAccessClientID := clientIDSlug + "-vault"
+	vaultAccessClientID := participantContextID + "-vault"
 	vaultAccessClient, err := newKeycloakClientData(participantContextID, WithClientID(vaultAccessClientID), WithName("Vault Access Client"), WithDescription("Client for Vault to access Keycloak"), WithEnabled(true))
 	if err != nil {
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: err}
@@ -251,30 +218,17 @@ func (p KeyCloakActivityProcessor) ProcessDeploy(ctx api.ActivityContext) api.Ac
 }
 
 func (p KeyCloakActivityProcessor) ProcessDispose(ctx api.ActivityContext) api.ActivityResult {
-	apiAccessID := ctx.Values()[apiAccessClientIDKey].(string)
 	vaultAccessID := ctx.Values()[vaultAccessClientIDKey].(string)
-	if vaultAccessID != "" && apiAccessID != "" {
+	if vaultAccessID != "" {
 		vaultErr := p.deleteClient(ctx.Context(), vaultAccessID)
 		p.monitor.Debugf("deleted Vault Access client: %s", vaultAccessID)
-		apiErr := p.deleteClient(ctx.Context(), apiAccessID)
-		p.monitor.Debugf("deleted API Access client: %s", apiAccessID)
 
-		var errors []error
 		if vaultErr != nil {
-			errors = append(errors, vaultErr)
-		}
-		if apiErr != nil {
-			errors = append(errors, apiErr)
-		}
-		if len(errors) > 0 {
-			return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("could not roll back Keycloak clients: %v", errors)}
+			return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("could not roll back Keycloak clients: %v", vaultErr)}
 		}
 		return api.ActivityResult{Result: api.ActivityResultComplete}
 	}
 
-	if apiAccessID == "" {
-		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("could not roll back Keycloak API access client: the '%s' output value is not set", apiAccessClientIDKey)}
-	}
 	// implicitly, vaultAccessID is empty
 	return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("could not roll back Keycloak vault access client: the '%s' output value is not set", vaultAccessClientIDKey)}
 

--- a/agent/keycloak/activity/activity.go
+++ b/agent/keycloak/activity/activity.go
@@ -200,9 +200,10 @@ func (p KeyCloakActivityProcessor) ProcessDeploy(ctx api.ActivityContext) api.Ac
 
 	var participantContextID string
 	if inputData.ParticipantContextID == "" {
-		participantContextID = inputData.ParticipantContextID
-	} else {
+		p.monitor.Warnf("participantContextId not found on processing data, generating a random ID")
 		participantContextID = generateClientID()
+	} else {
+		participantContextID = inputData.ParticipantContextID
 	}
 
 	// create a Vault access client in Keycloak

--- a/agent/keycloak/activity/activity.go
+++ b/agent/keycloak/activity/activity.go
@@ -202,6 +202,7 @@ func (p KeyCloakActivityProcessor) ProcessDeploy(ctx api.ActivityContext) api.Ac
 	if inputData.ParticipantContextID == "" {
 		p.monitor.Warnf("participantContextId not found on processing data, generating a random ID")
 		participantContextID = generateClientID()
+		ctx.SetValue(participantContextIDKey, participantContextID)
 	} else {
 		participantContextID = inputData.ParticipantContextID
 	}

--- a/agent/keycloak/activity/activity.go
+++ b/agent/keycloak/activity/activity.go
@@ -187,15 +187,23 @@ func NewProcessor(config *Config) *KeyCloakActivityProcessor {
 
 func (p KeyCloakActivityProcessor) ProcessDeploy(ctx api.ActivityContext) api.ActivityResult {
 
+	type input struct {
+		ParticipantContextID string `json:"participantContextId"`
+	}
+	var inputData input
+	if err := ctx.ReadValues(&inputData); err != nil {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing Keycloak activity for orchestration %s: %w", ctx.OID(), err)}
+	}
+
 	_, span := otel.GetTracerProvider().Tracer(tracerName).Start(ctx.Context(), "agent.kcagent.deploy")
 	defer span.End()
 
-	pcId, ok := ctx.Value(participantContextIDKey)
-	if !ok {
-		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("participant context ID not found in activity context")}
+	var participantContextID string
+	if inputData.ParticipantContextID == "" {
+		participantContextID = inputData.ParticipantContextID
+	} else {
+		participantContextID = generateClientID()
 	}
-
-	participantContextID := pcId.(string)
 
 	// create a Vault access client in Keycloak
 	vaultAccessClientID := participantContextID + "-vault"

--- a/agent/keycloak/e2e/e2e_test.go
+++ b/agent/keycloak/e2e/e2e_test.go
@@ -56,7 +56,7 @@ func Test_SuccessfulDeployment(t *testing.T) {
 	require.NoError(t, err)
 	defer vaultClient.Close()
 
-	var apiAccessClientID, vaultAccessClientId string
+	var participantContextId, vaultAccessClientId string
 	require.Eventually(t, func() bool {
 		oEntry, err := natsContainer.Client.KVStore.Get(ctx, "1234")
 		if err != nil {
@@ -68,16 +68,16 @@ func Test_SuccessfulDeployment(t *testing.T) {
 			return false
 		}
 		if orchestration.State == api.OrchestrationStateCompleted {
-			apiAccessClientID = orchestration.ProcessingData["clientID.apiAccess"].(string)
+			participantContextId = orchestration.ProcessingData["participantContextId"].(string)
 			vaultAccessClientId = orchestration.ProcessingData["clientID.vaultAccess"].(string)
 			return true
 		}
 		return false
 	}, 10*time.Second, 10*time.Millisecond, "Orchestration did not complete in time")
 
-	require.NotEmpty(t, apiAccessClientID, "Expected clientID.apiAccess to be set")
+	//require.NotEmpty(t, participantContextId, "Expected participantContextId to be set")
 	require.NotEmpty(t, vaultAccessClientId, "Expected clientID.vaultAccess to be set")
-	apiAccessSecret, err := vaultClient.ResolveSecret(ctx, apiAccessClientID)
+	apiAccessSecret, err := vaultClient.ResolveSecret(ctx, participantContextId)
 	require.NoError(t, err, "Failed to resolve secret")
 	require.NotEmpty(t, apiAccessSecret, "Expected api access client secret to be set")
 	vaultAccessSecret, err := vaultClient.ResolveSecret(ctx, vaultAccessClientId)
@@ -114,7 +114,7 @@ func Test_UnsupportedDiscriminator(t *testing.T) {
 			return false
 		}
 		if orchestration.State == api.OrchestrationStateErrored {
-			require.Nil(t, orchestration.ProcessingData["clientID.apiAccess"])
+			require.Nil(t, orchestration.ProcessingData["participantContextId"])
 			require.Nil(t, orchestration.ProcessingData["clientID.vaultAccess"])
 			return true
 		}

--- a/agent/keycloak/e2e/e2e_test.go
+++ b/agent/keycloak/e2e/e2e_test.go
@@ -75,11 +75,8 @@ func Test_SuccessfulDeployment(t *testing.T) {
 		return false
 	}, 10*time.Second, 10*time.Millisecond, "Orchestration did not complete in time")
 
-	//require.NotEmpty(t, participantContextId, "Expected participantContextId to be set")
+	require.NotEmpty(t, participantContextId, "Expected participantContextId to be set")
 	require.NotEmpty(t, vaultAccessClientId, "Expected clientID.vaultAccess to be set")
-	apiAccessSecret, err := vaultClient.ResolveSecret(ctx, participantContextId)
-	require.NoError(t, err, "Failed to resolve secret")
-	require.NotEmpty(t, apiAccessSecret, "Expected api access client secret to be set")
 	vaultAccessSecret, err := vaultClient.ResolveSecret(ctx, vaultAccessClientId)
 	require.NoError(t, err, "Failed to resolve secret")
 	require.NotEmpty(t, vaultAccessSecret, "Expected vault access client secret to be set")

--- a/agent/onboarding/activity/activity.go
+++ b/agent/onboarding/activity/activity.go
@@ -37,7 +37,7 @@ type OnboardingActivityProcessor struct {
 
 type credentialRequestData struct {
 	//CredentialRequest    identityhub.CredentialRequest `json:"credentialRequest"`
-	ParticipantContextID string `json:"clientID.apiAccess" validate:"required"`
+	ParticipantContextID string `json:"participantContextId" validate:"required"`
 	HolderPID            string `json:"holderPid"`
 	CredentialRequestURL string `json:"credentialRequest"`
 }

--- a/agent/onboarding/activity/activity_test.go
+++ b/agent/onboarding/activity/activity_test.go
@@ -35,7 +35,7 @@ func TestOnboardingActivityProcessor_ProcessDeploy_WhenNewRequest(t *testing.T) 
 	}
 
 	var processingData = map[string]any{
-		"clientID.apiAccess": "test-participant",
+		"participantContextId": "test-participant",
 		"cfm.vpa.credentials": []any{
 			map[string]string{
 				"id":     "id",
@@ -77,7 +77,7 @@ func TestOnboardingActivityProcessor_ProcessDeploy_WhenNewRequestError(t *testin
 	}
 
 	var processingData = map[string]any{
-		"clientID.apiAccess": "test-participant",
+		"participantContextId": "test-participant",
 		"cfm.vpa.credentials": []any{
 			map[string]string{
 				"id":     "id",
@@ -116,7 +116,6 @@ func TestOnboardingActivityProcessor_ProcessDeploy_WhenPendingRequestApiError(t 
 	}
 
 	var processingData = map[string]any{
-		"clientID.apiAccess":   "test-participant",
 		"participantContextId": "test-participant",
 		"holderPid":            "test-holder-pid",
 		"credentialRequest":    "https://example.com/credentialservice/request/123",
@@ -150,7 +149,6 @@ func TestOnboardingActivityProcessor_ProcessDeploy_WhenPendingRequestIssued(t *t
 	}
 
 	var processingData = map[string]any{
-		"clientID.apiAccess":   "test-participant",
 		"participantContextId": "test-participant",
 		"holderPid":            "test-holder-pid",
 		"credentialRequest":    "https://example.com/credentialservice/request/123",
@@ -187,7 +185,6 @@ func TestOnboardingActivityProcessor_ProcessDeploy_WhenPendingRequestCreated(t *
 	}
 
 	var processingData = map[string]any{
-		"clientID.apiAccess":   "test-participant",
 		"participantContextId": "test-participant",
 		"holderPid":            "test-holder-pid",
 		"credentialRequest":    "https://example.com/credentialservice/request/123",
@@ -222,7 +219,6 @@ func TestOnboardingActivityProcessor_ProcessDeploy_WhenPendingRequestError(t *te
 	}
 
 	var processingData = map[string]any{
-		"clientID.apiAccess":   "test-participant",
 		"participantContextId": "test-participant",
 		"holderPid":            "test-holder-pid",
 		"credentialRequest":    "https://example.com/credentialservice/request/123",
@@ -283,7 +279,6 @@ func TestOnboardingActivityProcessor_ProcessDeploy_WhenInvalidStateReceived(t *t
 	}
 
 	var processingData = map[string]any{
-		"clientID.apiAccess":   "test-participant",
 		"participantContextId": "test-participant",
 		"holderPid":            "test-holder-pid",
 		"credentialRequest":    "https://example.com/credentialservice/request/123",
@@ -325,7 +320,7 @@ func TestOnboardingActivityProcessor_ProcessDispose(t *testing.T) {
 	}
 
 	var processingData = map[string]any{
-		"clientID.apiAccess": "test-participant",
+		"participantContextId": "test-participant",
 		"cfm.vpa.credentials": []any{
 			map[string]string{
 				"id":     "id",
@@ -372,7 +367,7 @@ func TestOnboardingActivityProcessor_ProcessDispose_RevocationFails(t *testing.T
 	}
 
 	var processingData = map[string]any{
-		"clientID.apiAccess": "test-participant",
+		"participantContextId": "test-participant",
 		"cfm.vpa.credentials": []any{
 			map[string]string{
 				"id":     "id",
@@ -413,7 +408,7 @@ func TestOnboardingActivityProcessor_ProcessDispose_NoCredentials(t *testing.T) 
 	}
 
 	var processingData = map[string]any{
-		"clientID.apiAccess": "test-participant",
+		"participantContextId": "test-participant",
 		"cfm.vpa.credentials": []any{
 			map[string]string{
 				"id":     "id",

--- a/agent/onboarding/activity/activity_test.go
+++ b/agent/onboarding/activity/activity_test.go
@@ -474,12 +474,12 @@ func (m MockIssuerServiceApiClient) QueryCredentialsByType(ctx context.Context, 
 
 }
 
-func (m MockIssuerServiceApiClient) DeleteHolder(ctx context.Context, holderID string) error {
+func (m MockIssuerServiceApiClient) DeleteHolder(ctx context.Context, participantContextID string, holderID string) error {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (m MockIssuerServiceApiClient) CreateHolder(ctx context.Context, did string, holderID string, name string, properties map[string]any) error {
+func (m MockIssuerServiceApiClient) CreateHolder(ctx context.Context, participantContextID string, did string, holderID string, name string, properties map[string]any) error {
 	return m.expectedError
 }
 

--- a/agent/onboarding/launcher/launcher.go
+++ b/agent/onboarding/launcher/launcher.go
@@ -20,9 +20,9 @@ import (
 	"github.com/eclipse-cfm/cfm/agent/onboarding/activity"
 	"github.com/eclipse-cfm/cfm/assembly/httpclient"
 	"github.com/eclipse-cfm/cfm/assembly/serviceapi"
-	"github.com/eclipse-cfm/cfm/common/oauth2"
 	"github.com/eclipse-cfm/cfm/common/runtime"
 	"github.com/eclipse-cfm/cfm/common/system"
+	"github.com/eclipse-cfm/cfm/common/tokenexchange"
 	"github.com/eclipse-cfm/cfm/pmanager/api"
 	"github.com/eclipse-cfm/cfm/pmanager/natsagent"
 )
@@ -35,6 +35,9 @@ const (
 	tokenURLKey             = "keycloak.tokenUrl"
 	issuerServiceBaseUrlKey = "issuerservice.url"
 	issuerIDKey             = "issuer.id"
+	tokenExchangeURLKey     = "tokenexchange.url"
+	tokenFilePathKey        = "tokenexchange.tokenFilePath"
+	audienceKey             = "tokenexchange.audience"
 )
 
 func LaunchAndWaitSignal(shutdown <-chan struct{}) {
@@ -61,13 +64,10 @@ func LaunchAndWaitSignal(shutdown <-chan struct{}) {
 				panic(err)
 			}
 
-			provider := oauth2.NewTokenProvider(
-				oauth2.Oauth2Params{
-					ClientID:     clientID,
-					ClientSecret: clientSecret,
-					TokenURL:     tokenURL,
-					GrantType:    oauth2.ClientCredentials,
-				}, &httpClient)
+			provider := tokenexchange.NewTokenExchangeProvider(ctx.Config.GetString(tokenFilePathKey),
+				tokenexchange.WithTokenExchangeUrl(ctx.Config.GetString(tokenExchangeURLKey)),
+				tokenexchange.WithTokenExchangeAudience(ctx.Config.GetString(audienceKey)),
+				tokenexchange.WithHttpClient(&httpClient))
 
 			return activity.OnboardingActivityProcessor{
 				Monitor: ctx.Monitor,

--- a/agent/registration/activity/activity.go
+++ b/agent/registration/activity/activity.go
@@ -30,8 +30,9 @@ type RegistrationActivityProcessor struct {
 }
 
 type registrationData struct {
-	DID        string `json:"cfm.participant.id" validate:"required"`
-	HolderName string `json:"cfm.participant.holdername"`
+	DID                  string `json:"cfm.participant.id" validate:"required"`
+	HolderName           string `json:"cfm.participant.holdername"`
+	ParticipantContextId string `json:"participantContextId" validate:"required"`
 }
 
 func NewProcessor(config *Config) *RegistrationActivityProcessor {
@@ -65,7 +66,7 @@ func (p RegistrationActivityProcessor) ProcessDeploy(ctx api.ActivityContext) ap
 		span.RecordError(err)
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error reading vpa data: %w", err)}
 	}
-	if err := p.IssuerService.CreateHolder(ctx.Context(), regData.DID, holderID, regData.HolderName, properties); err != nil {
+	if err := p.IssuerService.CreateHolder(ctx.Context(), regData.ParticipantContextId, regData.DID, holderID, regData.HolderName, properties); err != nil {
 		span.RecordError(err)
 		// todo: inspect error if it is retryable
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error creating holder in ApiClient: %w", err)}
@@ -75,15 +76,15 @@ func (p RegistrationActivityProcessor) ProcessDeploy(ctx api.ActivityContext) ap
 }
 
 func (p RegistrationActivityProcessor) ProcessDispose(ctx api.ActivityContext) api.ActivityResult {
-	var registrationData registrationData
-	if err := ctx.ReadValues(&registrationData); err != nil {
+	var regData registrationData
+	if err := ctx.ReadValues(&regData); err != nil {
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error processing Registration activity for orchestration %s: %w", ctx.OID(), err)}
 	}
-	holderID := registrationData.DID
-	if err := p.IssuerService.DeleteHolder(ctx.Context(), holderID); err != nil {
+	holderID := regData.DID
+	if err := p.IssuerService.DeleteHolder(ctx.Context(), regData.ParticipantContextId, holderID); err != nil {
 		// todo: inspect error if it is retryable
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("registration rollback: error deleting holder in IssuerService: %w", err)}
 	}
-	p.Monitor.Debugf("Registration rollback: activity for participant '%s' completed successfully", registrationData.DID)
+	p.Monitor.Debugf("Registration rollback: activity for participant '%s' completed successfully", regData.DID)
 	return api.ActivityResult{Result: api.ActivityResultComplete}
 }

--- a/agent/registration/activity/activity_test.go
+++ b/agent/registration/activity/activity_test.go
@@ -41,6 +41,7 @@ func TestRegistrationActivityProcessor_MinimalValidData(t *testing.T) {
 	}
 
 	processingData := map[string]any{
+		"participantContextId":      "some-context-id",
 		model.ParticipantIdentifier: "did:web:someparticipant",
 		model.VPAData:               validVpaData(nil),
 	}
@@ -72,6 +73,7 @@ func TestRegistrationActivityProcessor_FullValidData(t *testing.T) {
 	}
 
 	processingData := map[string]any{
+		"participantContextId":       "some-context-id",
 		model.ParticipantIdentifier:  "did:web:someparticipant",
 		"cfm.participant.holdername": "some holder",
 		model.VPAData:                validVpaData(nil),
@@ -130,6 +132,7 @@ func TestRegistrationActivityProcessor_IssuerServiceFails(t *testing.T) {
 	}
 
 	processingData := map[string]any{
+		"participantContextId":      "some-context-id",
 		model.ParticipantIdentifier: "did:web:someparticipant",
 		model.VPAData:               validVpaData(nil),
 	}
@@ -150,6 +153,7 @@ func TestRegistrationActivityProcessor_VpaDataMissing(t *testing.T) {
 	})
 
 	processingData := map[string]any{
+		"participantContextId":      "some-context-id",
 		model.ParticipantIdentifier: "did:web:someparticipant",
 	}
 
@@ -165,6 +169,29 @@ func TestRegistrationActivityProcessor_VpaDataMissing(t *testing.T) {
 	assert.NoError(t, result.Error)
 }
 
+func TestRegistrationActivityProcessor_ParticipantContextIDMissing(t *testing.T) {
+	issuerService := MockIssuerService{}
+	processor := NewProcessor(&Config{
+		LogMonitor:    system.NoopMonitor{},
+		IssuerService: &issuerService,
+	})
+
+	processingData := map[string]any{
+		model.ParticipantIdentifier: "did:web:someparticipant",
+	}
+
+	activityContext := api.NewActivityContext(context.Background(), "orch-123", api.Activity{
+		ID:            "test-activity",
+		Type:          "edcv",
+		Discriminator: api.DeployDiscriminator,
+	}, processingData, make(map[string]any))
+
+	result := processor.ProcessDeploy(activityContext)
+
+	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
+	assert.Error(t, result.Error)
+}
+
 func TestRegistrationActivityProcessor_VpaDataEmptySlice(t *testing.T) {
 	issuerService := MockIssuerService{}
 	processor := NewProcessor(&Config{
@@ -173,6 +200,7 @@ func TestRegistrationActivityProcessor_VpaDataEmptySlice(t *testing.T) {
 	})
 
 	processingData := map[string]any{
+		"participantContextId":      "some-context-id",
 		model.ParticipantIdentifier: "did:web:someparticipant",
 		model.VPAData:               []any{},
 	}
@@ -197,6 +225,7 @@ func TestRegistrationActivityProcessor_VpaDataTypeMismatch(t *testing.T) {
 	})
 
 	processingData := map[string]any{
+		"participantContextId":      "some-context-id",
 		model.ParticipantIdentifier: "did:web:someparticipant",
 		model.VPAData: []any{
 			map[string]any{
@@ -226,6 +255,7 @@ func TestRegistrationActivityProcessor_VpaDataPropertiesPassedToIssuerService(t 
 
 	props := map[string]any{"region": "eu-west", "tier": "standard"}
 	processingData := map[string]any{
+		"participantContextId":      "some-context-id",
 		model.ParticipantIdentifier: "did:web:someparticipant",
 		model.VPAData:               validVpaData(props),
 	}
@@ -252,6 +282,7 @@ func TestRegistrationActivityProcessor_VpaDataNoProperties(t *testing.T) {
 	})
 
 	processingData := map[string]any{
+		"participantContextId":      "some-context-id",
 		model.ParticipantIdentifier: "did:web:someparticipant",
 		model.VPAData: []any{
 			map[string]any{
@@ -290,6 +321,7 @@ func TestRegistrationActivityProcessor_ProcessDispose(t *testing.T) {
 	}
 
 	processingData := map[string]any{
+		"participantContextId":      "some-context-id",
 		model.ParticipantIdentifier: "did:web:someparticipant",
 	}
 
@@ -318,6 +350,7 @@ func TestRegistrationActivityProcessor_ProcessDispose_IssuerServiceFails(t *test
 	}
 
 	processingData := map[string]any{
+		"participantContextId":      "some-context-id",
 		model.ParticipantIdentifier: "did:web:someparticipant",
 	}
 

--- a/agent/registration/activity/activity_test.go
+++ b/agent/registration/activity/activity_test.go
@@ -357,7 +357,7 @@ func (m *MockIssuerService) QueryCredentialsByType(ctx context.Context, particip
 	return nil, nil
 }
 
-func (m *MockIssuerService) DeleteHolder(ctx context.Context, holderID string) error {
+func (m *MockIssuerService) DeleteHolder(ctx context.Context, participantContextID string, holderID string) error {
 	return m.expectedError
 }
 
@@ -365,7 +365,7 @@ func (m *MockIssuerService) RevokeCredential(ctx context.Context, participantCon
 	return nil
 }
 
-func (m *MockIssuerService) CreateHolder(ctx context.Context, did string, holderID string, name string, properties map[string]any) error {
+func (m *MockIssuerService) CreateHolder(ctx context.Context, participantContextID string, did string, holderID string, name string, properties map[string]any) error {
 	m.recorded.did = did
 	m.recorded.holderID = holderID
 	m.recorded.name = name

--- a/agent/registration/launcher/launcher.go
+++ b/agent/registration/launcher/launcher.go
@@ -19,9 +19,9 @@ import (
 	"github.com/eclipse-cfm/cfm/agent/registration/activity"
 	"github.com/eclipse-cfm/cfm/assembly/httpclient"
 	"github.com/eclipse-cfm/cfm/assembly/serviceapi"
-	"github.com/eclipse-cfm/cfm/common/oauth2"
 	"github.com/eclipse-cfm/cfm/common/runtime"
 	"github.com/eclipse-cfm/cfm/common/system"
+	"github.com/eclipse-cfm/cfm/common/tokenexchange"
 	"github.com/eclipse-cfm/cfm/pmanager/api"
 	"github.com/eclipse-cfm/cfm/pmanager/natsagent"
 )
@@ -30,9 +30,11 @@ const (
 	ActivityType            = "registration-activity"
 	clientIDKey             = "keycloak.clientID"
 	clientSecretKey         = "keycloak.clientSecret"
-	tokenURLKey             = "keycloak.tokenUrl"
 	issuerServiceBaseUrlKey = "issuerservice.url"
 	issuerIDKey             = "issuer.id"
+	tokenExchangeURLKey     = "tokenexchange.url"
+	tokenFilePathKey        = "tokenexchange.tokenFilePath"
+	audienceKey             = "tokenexchange.audience"
 )
 
 func LaunchAndWaitSignal(shutdown <-chan struct{}) {
@@ -50,7 +52,6 @@ func LaunchAndWaitSignal(shutdown <-chan struct{}) {
 			httpClient := ctx.Registry.Resolve(serviceapi.HttpClientKey).(http.Client)
 			clientID := ctx.Config.GetString(clientIDKey)
 			clientSecret := ctx.Config.GetString(clientSecretKey)
-			tokenURL := ctx.Config.GetString(tokenURLKey) // this may be nil or "" if the in-mem vault is used
 			issuerServiceBaseUrl := ctx.Config.GetString(issuerServiceBaseUrlKey)
 			issuerID := ctx.Config.GetString(issuerIDKey)
 
@@ -58,13 +59,10 @@ func LaunchAndWaitSignal(shutdown <-chan struct{}) {
 				panic(err)
 			}
 
-			provider := oauth2.NewTokenProvider(
-				oauth2.Oauth2Params{
-					ClientID:     clientID,
-					ClientSecret: clientSecret,
-					TokenURL:     tokenURL,
-					GrantType:    oauth2.ClientCredentials,
-				}, &httpClient)
+			provider := tokenexchange.NewTokenExchangeProvider(ctx.Config.GetString(tokenFilePathKey),
+				tokenexchange.WithTokenExchangeUrl(ctx.Config.GetString(tokenExchangeURLKey)),
+				tokenexchange.WithTokenExchangeAudience(ctx.Config.GetString(audienceKey)),
+				tokenexchange.WithHttpClient(&httpClient))
 			return activity.NewProcessor(&activity.Config{
 				LogMonitor: ctx.Monitor,
 				IssuerService: issuerservice.HttpApiClient{

--- a/common/mocks/token_provider.go
+++ b/common/mocks/token_provider.go
@@ -22,7 +22,7 @@ func (_m *MockTokenProvider) EXPECT() *MockTokenProvider_Expecter {
 }
 
 // GetToken provides a mock function with given fields: ctx
-func (_m *MockTokenProvider) GetToken(ctx context.Context) (string, error) {
+func (_m *MockTokenProvider) GetToken(ctx context.Context, scope string, participantContextId string) (string, error) {
 	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {

--- a/common/mocks/token_provider.go
+++ b/common/mocks/token_provider.go
@@ -21,9 +21,9 @@ func (_m *MockTokenProvider) EXPECT() *MockTokenProvider_Expecter {
 	return &MockTokenProvider_Expecter{mock: &_m.Mock}
 }
 
-// GetToken provides a mock function with given fields: ctx
-func (_m *MockTokenProvider) GetToken(ctx context.Context, scope string, participantContextId string) (string, error) {
-	ret := _m.Called(ctx)
+// GetToken provides a mock function with given fields: ctx, scope, participantId
+func (_m *MockTokenProvider) GetToken(ctx context.Context, scope string, participantId string) (string, error) {
+	ret := _m.Called(ctx, scope, participantId)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetToken")
@@ -31,17 +31,17 @@ func (_m *MockTokenProvider) GetToken(ctx context.Context, scope string, partici
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context) (string, error)); ok {
-		return rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (string, error)); ok {
+		return rf(ctx, scope, participantId)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context) string); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) string); ok {
+		r0 = rf(ctx, scope, participantId)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = rf(ctx)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, scope, participantId)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -56,13 +56,15 @@ type MockTokenProvider_GetToken_Call struct {
 
 // GetToken is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockTokenProvider_Expecter) GetToken(ctx interface{}) *MockTokenProvider_GetToken_Call {
-	return &MockTokenProvider_GetToken_Call{Call: _e.mock.On("GetToken", ctx)}
+//   - scope string
+//   - participantId string
+func (_e *MockTokenProvider_Expecter) GetToken(ctx interface{}, scope interface{}, participantId interface{}) *MockTokenProvider_GetToken_Call {
+	return &MockTokenProvider_GetToken_Call{Call: _e.mock.On("GetToken", ctx, scope, participantId)}
 }
 
-func (_c *MockTokenProvider_GetToken_Call) Run(run func(ctx context.Context)) *MockTokenProvider_GetToken_Call {
+func (_c *MockTokenProvider_GetToken_Call) Run(run func(ctx context.Context, scope string, participantId string)) *MockTokenProvider_GetToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
 	})
 	return _c
 }
@@ -72,7 +74,7 @@ func (_c *MockTokenProvider_GetToken_Call) Return(_a0 string, _a1 error) *MockTo
 	return _c
 }
 
-func (_c *MockTokenProvider_GetToken_Call) RunAndReturn(run func(context.Context) (string, error)) *MockTokenProvider_GetToken_Call {
+func (_c *MockTokenProvider_GetToken_Call) RunAndReturn(run func(context.Context, string, string) (string, error)) *MockTokenProvider_GetToken_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/common/oauth2/oauth2.go
+++ b/common/oauth2/oauth2.go
@@ -58,10 +58,10 @@ func NewTokenProvider(params Oauth2Params, client *http.Client) *TokenProvider {
 }
 
 // GetToken gets an OAuth2 token using the grant type specified in the Oauth2Params
-func (t *TokenProvider) GetToken(ctx context.Context) (string, error) {
+func (t *TokenProvider) GetToken(ctx context.Context, scope string, participantContextId string) (string, error) {
 	switch t.tokenParams.GrantType {
 	case "client_credentials":
-		return t.getClientCredentialsToken(ctx)
+		return t.getClientCredentialsToken(ctx, scope)
 	case "password":
 		return t.getPasswordCredentialsToken(ctx)
 	default:
@@ -69,7 +69,7 @@ func (t *TokenProvider) GetToken(ctx context.Context) (string, error) {
 	}
 }
 
-func (t *TokenProvider) getClientCredentialsToken(ctx context.Context) (string, error) {
+func (t *TokenProvider) getClientCredentialsToken(ctx context.Context, scope string) (string, error) {
 	tokenURL := t.tokenParams.TokenURL
 	clientID := t.tokenParams.ClientID
 	clientSecret := t.tokenParams.ClientSecret
@@ -79,7 +79,7 @@ func (t *TokenProvider) getClientCredentialsToken(ctx context.Context) (string, 
 		return "", err
 	}
 
-	formData := fmt.Sprintf("client_id=%s&client_secret=%s&grant_type=%s", clientID, clientSecret, ClientCredentials)
+	formData := fmt.Sprintf("client_id=%s&client_secret=%s&grant_type=%s&scope=%s", clientID, clientSecret, ClientCredentials, scope)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(formData))
 	if err != nil {

--- a/common/token/token_provider.go
+++ b/common/token/token_provider.go
@@ -17,7 +17,9 @@ package token
 import "context"
 
 // TokenProvider gets tokens, most likely access tokens, API Keys, OAuth2 tokens, etc.
+// scope is a string that describes the intended use of the token, for example, "identity-api:read"
+// participantId is a string that identifies the participant for which the token is intended. Most likely, this is the participant's DID
 type TokenProvider interface {
-	GetToken(ctx context.Context) (string, error)
+	GetToken(ctx context.Context, scope string, participantId string) (string, error)
 	// todo: implement refresh
 }

--- a/common/tokenexchange/tokenprovider.go
+++ b/common/tokenexchange/tokenprovider.go
@@ -15,20 +15,15 @@
 package tokenexchange
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 	"os"
+	"strings"
 )
-
-type tokenExchangeRequest struct {
-	GrantType    string `json:"grant_type"`
-	SubjectToken string `json:"subject_token"`
-	Resource     string `json:"resource"`
-	Scope        string `json:"scope"`
-	Audience     string `json:"audience"`
-}
 
 type tokenExchangeResponse struct {
 	AccessToken     string `json:"access_token"`
@@ -48,43 +43,78 @@ type TokenExchangeProvider struct {
 	httpClient            *http.Client
 }
 
-func NewTokenExchangeProvider(filename string) TokenExchangeProvider {
-	return TokenExchangeProvider{
-		filePath: filename,
+// ProviderOption is a functional option for configuring TokenExchangeProvider
+type ProviderOption func(*TokenExchangeProvider)
+
+// WithTokenExchangeUrl sets the URL of the token exchange server (jwtlet)
+func WithTokenExchangeUrl(url string) ProviderOption {
+	return func(t *TokenExchangeProvider) {
+		t.tokenExchangeUrl = url
 	}
 }
 
-func (t TokenExchangeProvider) GetToken(ctx context.Context) (string, error) {
+// WithTokenExchangeAudience sets the token exchange audience (e.g. "edcv"). all downstream services must validate against this audience
+func WithTokenExchangeAudience(audience string) ProviderOption {
+	return func(t *TokenExchangeProvider) {
+		t.tokenExchangeAudience = audience
+	}
+}
+
+// WithHttpClient sets the HTTP client
+func WithHttpClient(client *http.Client) ProviderOption {
+	return func(t *TokenExchangeProvider) {
+		t.httpClient = client
+	}
+}
+
+// NewTokenExchangeProvider creates a new TokenExchangeProvider with the given token file path and options
+// tokenFilePath: the absolute path to the file that contains the token
+func NewTokenExchangeProvider(tokenFilePath string, opts ...ProviderOption) TokenExchangeProvider {
+	provider := TokenExchangeProvider{
+		filePath: tokenFilePath,
+	}
+	for _, opt := range opts {
+		opt(&provider)
+	}
+	return provider
+}
+
+func (t TokenExchangeProvider) GetToken(ctx context.Context, scope string, participantIdentifier string) (string, error) {
 	content, err := os.ReadFile(t.filePath)
 	if err != nil {
 		return "", err
 	}
 
-	body := tokenExchangeRequest{
-		GrantType:    "urn:ietf:params:oauth:grant-type:token-exchange",
-		SubjectToken: string(content),
-		Resource:     "did:web:foobar",
-		Scope:        "read write",
-		Audience:     t.tokenExchangeAudience,
-	}
+	formData := url.Values{}
+	formData.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+	formData.Set("subject_token", string(content))
+	formData.Set("resource", participantIdentifier)
+	formData.Set("scope", scope)
+	formData.Set("audience", t.tokenExchangeAudience)
 
-	jsonBody, err := json.Marshal(body)
+	req, err := http.NewRequestWithContext(ctx, "POST", t.tokenExchangeUrl+"/token", strings.NewReader(formData.Encode()))
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("error creating token exchange request: %w", err)
 	}
-	req, _ := http.NewRequestWithContext(ctx, "POST", t.tokenExchangeUrl, bytes.NewBuffer(jsonBody))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	resp, err := t.httpClient.Do(req)
-
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("error sending token exchange request: %w", err)
 	}
 	defer resp.Body.Close()
 
-	var tokenResponse tokenExchangeResponse
-	err = json.NewDecoder(resp.Body).Decode(&tokenResponse)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("error reading response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("token exchange failed with status %d", resp.StatusCode)
+	}
+	var tokenResponse tokenExchangeResponse
+	err = json.Unmarshal(bodyBytes, &tokenResponse)
+	if err != nil {
+		return "", fmt.Errorf("error decoding token exchange response: %w", err)
 	}
 
 	return tokenResponse.AccessToken, nil

--- a/common/tokenexchange/tokenprovider.go
+++ b/common/tokenexchange/tokenprovider.go
@@ -23,6 +23,8 @@ import (
 	"net/url"
 	"os"
 	"strings"
+
+	"github.com/eclipse-cfm/cfm/common/system"
 )
 
 type tokenExchangeResponse struct {
@@ -41,6 +43,7 @@ type TokenExchangeProvider struct {
 	tokenExchangeUrl      string
 	tokenExchangeAudience string
 	httpClient            *http.Client
+	monitor               system.LogMonitor
 }
 
 // ProviderOption is a functional option for configuring TokenExchangeProvider
@@ -67,11 +70,19 @@ func WithHttpClient(client *http.Client) ProviderOption {
 	}
 }
 
+// WithMonitor sets the log monitor
+func WithMonitor(monitor system.LogMonitor) ProviderOption {
+	return func(t *TokenExchangeProvider) {
+		t.monitor = monitor
+	}
+}
+
 // NewTokenExchangeProvider creates a new TokenExchangeProvider with the given token file path and options
 // tokenFilePath: the absolute path to the file that contains the token
 func NewTokenExchangeProvider(tokenFilePath string, opts ...ProviderOption) TokenExchangeProvider {
 	provider := TokenExchangeProvider{
 		filePath: tokenFilePath,
+		monitor:  system.NoopMonitor{},
 	}
 	for _, opt := range opts {
 		opt(&provider)
@@ -79,7 +90,8 @@ func NewTokenExchangeProvider(tokenFilePath string, opts ...ProviderOption) Toke
 	return provider
 }
 
-func (t TokenExchangeProvider) GetToken(ctx context.Context, scope string, participantIdentifier string) (string, error) {
+func (t TokenExchangeProvider) GetToken(ctx context.Context, scope string, participantContextID string) (string, error) {
+	t.monitor.Debugw("reading subject token from file", "path", t.filePath)
 	content, err := os.ReadFile(t.filePath)
 	if err != nil {
 		return "", err
@@ -88,10 +100,11 @@ func (t TokenExchangeProvider) GetToken(ctx context.Context, scope string, parti
 	formData := url.Values{}
 	formData.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
 	formData.Set("subject_token", string(content))
-	formData.Set("resource", participantIdentifier)
+	formData.Set("resource", participantContextID)
 	formData.Set("scope", scope)
 	formData.Set("audience", t.tokenExchangeAudience)
 
+	t.monitor.Debugw("sending token exchange request", "url", t.tokenExchangeUrl, "scope", scope, "resource", participantContextID, "audience", t.tokenExchangeAudience)
 	req, err := http.NewRequestWithContext(ctx, "POST", t.tokenExchangeUrl+"/token", strings.NewReader(formData.Encode()))
 	if err != nil {
 		return "", fmt.Errorf("error creating token exchange request: %w", err)
@@ -109,6 +122,7 @@ func (t TokenExchangeProvider) GetToken(ctx context.Context, scope string, parti
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		t.monitor.Debugw("token exchange failed", "status", resp.StatusCode, "body", string(bodyBytes))
 		return "", fmt.Errorf("token exchange failed with status %d", resp.StatusCode)
 	}
 	var tokenResponse tokenExchangeResponse
@@ -117,5 +131,6 @@ func (t TokenExchangeProvider) GetToken(ctx context.Context, scope string, parti
 		return "", fmt.Errorf("error decoding token exchange response: %w", err)
 	}
 
+	t.monitor.Debugw("token exchange successful", "scope", scope, "resource", participantContextID, "token_type", tokenResponse.TokenType, "expires_in", tokenResponse.ExpiresIn)
 	return tokenResponse.AccessToken, nil
 }

--- a/common/tokenexchange/tokenprovider.go
+++ b/common/tokenexchange/tokenprovider.go
@@ -1,0 +1,91 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package tokenexchange
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+)
+
+type tokenExchangeRequest struct {
+	GrantType    string `json:"grant_type"`
+	SubjectToken string `json:"subject_token"`
+	Resource     string `json:"resource"`
+	Scope        string `json:"scope"`
+	Audience     string `json:"audience"`
+}
+
+type tokenExchangeResponse struct {
+	AccessToken     string `json:"access_token"`
+	TokenType       string `json:"token_type"`
+	ExpiresIn       int    `json:"expires_in"`
+	Scope           string `json:"scope"`
+	IssuedTokenType string `json:"issued_token_type"`
+}
+
+// TokenExchangeProvider reads a token from a file share and exchanges it for a resource-bound token. The initial token is a
+// projected token bound to the workload ID (in Kubernetes: ServiceAccount), and the second token is a token bound to the
+// participant context
+type TokenExchangeProvider struct {
+	filePath              string
+	tokenExchangeUrl      string
+	tokenExchangeAudience string
+	httpClient            *http.Client
+}
+
+func NewTokenExchangeProvider(filename string) TokenExchangeProvider {
+	return TokenExchangeProvider{
+		filePath: filename,
+	}
+}
+
+func (t TokenExchangeProvider) GetToken(ctx context.Context) (string, error) {
+	content, err := os.ReadFile(t.filePath)
+	if err != nil {
+		return "", err
+	}
+
+	body := tokenExchangeRequest{
+		GrantType:    "urn:ietf:params:oauth:grant-type:token-exchange",
+		SubjectToken: string(content),
+		Resource:     "did:web:foobar",
+		Scope:        "read write",
+		Audience:     t.tokenExchangeAudience,
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return "", err
+	}
+	req, _ := http.NewRequestWithContext(ctx, "POST", t.tokenExchangeUrl, bytes.NewBuffer(jsonBody))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := t.httpClient.Do(req)
+
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var tokenResponse tokenExchangeResponse
+	err = json.NewDecoder(resp.Body).Decode(&tokenResponse)
+	if err != nil {
+		return "", err
+	}
+
+	return tokenResponse.AccessToken, nil
+}

--- a/common/tokenexchange/tokenprovider_test.go
+++ b/common/tokenexchange/tokenprovider_test.go
@@ -1,0 +1,274 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package tokenexchange
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testSubjectToken       = "subject-token-value"
+	testScope              = "test-scope:read"
+	testParticipantContext = "did:web:test-participant"
+	testAudience           = "test-audience"
+	testAccessToken        = "exchanged-access-token"
+)
+
+func writeTokenFile(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "token")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+	return path
+}
+
+func tokenResponse() tokenExchangeResponse {
+	return tokenExchangeResponse{
+		AccessToken:     testAccessToken,
+		TokenType:       "Bearer",
+		ExpiresIn:       3600,
+		Scope:           testScope,
+		IssuedTokenType: "urn:ietf:params:oauth:token-type:access_token",
+	}
+}
+
+func TestGetToken_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/token", r.URL.Path)
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		form, err := url.ParseQuery(string(body))
+		require.NoError(t, err)
+		assert.Equal(t, "urn:ietf:params:oauth:grant-type:token-exchange", form.Get("grant_type"))
+		assert.Equal(t, testSubjectToken, form.Get("subject_token"))
+		assert.Equal(t, testParticipantContext, form.Get("resource"))
+		assert.Equal(t, testScope, form.Get("scope"))
+		assert.Equal(t, testAudience, form.Get("audience"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(tokenResponse())
+	}))
+	defer server.Close()
+
+	tokenFile := writeTokenFile(t, testSubjectToken)
+	provider := NewTokenExchangeProvider(tokenFile,
+		WithTokenExchangeUrl(server.URL),
+		WithTokenExchangeAudience(testAudience),
+		WithHttpClient(&http.Client{}),
+	)
+
+	token, err := provider.GetToken(t.Context(), testScope, testParticipantContext)
+	require.NoError(t, err)
+	assert.Equal(t, testAccessToken, token)
+}
+
+func TestGetToken_TokenFileNotFound(t *testing.T) {
+	provider := NewTokenExchangeProvider("/nonexistent/path/token",
+		WithTokenExchangeUrl("http://unused"),
+		WithHttpClient(&http.Client{}),
+	)
+
+	token, err := provider.GetToken(t.Context(), testScope, testParticipantContext)
+	require.Error(t, err)
+	assert.Empty(t, token)
+}
+
+func TestGetToken_ServerReturns401(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	tokenFile := writeTokenFile(t, testSubjectToken)
+	provider := NewTokenExchangeProvider(tokenFile,
+		WithTokenExchangeUrl(server.URL),
+		WithHttpClient(&http.Client{}),
+	)
+
+	token, err := provider.GetToken(t.Context(), testScope, testParticipantContext)
+	require.ErrorContains(t, err, "token exchange failed with status 401")
+	assert.Empty(t, token)
+}
+
+func TestGetToken_ServerReturns500(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	tokenFile := writeTokenFile(t, testSubjectToken)
+	provider := NewTokenExchangeProvider(tokenFile,
+		WithTokenExchangeUrl(server.URL),
+		WithHttpClient(&http.Client{}),
+	)
+
+	token, err := provider.GetToken(t.Context(), testScope, testParticipantContext)
+	require.ErrorContains(t, err, "token exchange failed with status 500")
+	assert.Empty(t, token)
+}
+
+func TestGetToken_InvalidJsonResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not valid json"))
+	}))
+	defer server.Close()
+
+	tokenFile := writeTokenFile(t, testSubjectToken)
+	provider := NewTokenExchangeProvider(tokenFile,
+		WithTokenExchangeUrl(server.URL),
+		WithHttpClient(&http.Client{}),
+	)
+
+	token, err := provider.GetToken(t.Context(), testScope, testParticipantContext)
+	require.ErrorContains(t, err, "error decoding token exchange response")
+	assert.Empty(t, token)
+}
+
+func TestGetToken_HttpClientError(t *testing.T) {
+	tokenFile := writeTokenFile(t, testSubjectToken)
+	provider := NewTokenExchangeProvider(tokenFile,
+		WithTokenExchangeUrl("http://127.0.0.1:1"), // nothing listening here
+		WithHttpClient(&http.Client{}),
+	)
+
+	token, err := provider.GetToken(t.Context(), testScope, testParticipantContext)
+	require.ErrorContains(t, err, "error sending token exchange request")
+	assert.Empty(t, token)
+}
+
+func TestGetToken_InvalidUrl(t *testing.T) {
+	tokenFile := writeTokenFile(t, testSubjectToken)
+	provider := NewTokenExchangeProvider(tokenFile,
+		WithTokenExchangeUrl("://bad url"),
+		WithHttpClient(&http.Client{}),
+	)
+
+	token, err := provider.GetToken(t.Context(), testScope, testParticipantContext)
+	require.ErrorContains(t, err, "error creating token exchange request")
+	assert.Empty(t, token)
+}
+
+func TestGetToken_FormFieldsForwarded(t *testing.T) {
+	var capturedForm url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capturedForm, _ = url.ParseQuery(string(body))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(tokenExchangeResponse{AccessToken: testAccessToken})
+	}))
+	defer server.Close()
+
+	tokenFile := writeTokenFile(t, testSubjectToken)
+	provider := NewTokenExchangeProvider(tokenFile,
+		WithTokenExchangeUrl(server.URL),
+		WithTokenExchangeAudience("my-audience"),
+		WithHttpClient(&http.Client{}),
+	)
+
+	_, err := provider.GetToken(t.Context(), "my-scope", "did:web:alice")
+	require.NoError(t, err)
+	assert.Equal(t, "urn:ietf:params:oauth:grant-type:token-exchange", capturedForm.Get("grant_type"))
+	assert.Equal(t, testSubjectToken, capturedForm.Get("subject_token"))
+	assert.Equal(t, "did:web:alice", capturedForm.Get("resource"))
+	assert.Equal(t, "my-scope", capturedForm.Get("scope"))
+	assert.Equal(t, "my-audience", capturedForm.Get("audience"))
+}
+
+func TestGetToken_EmptyTokenFile(t *testing.T) {
+	var capturedSubjectToken string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		form, _ := url.ParseQuery(string(body))
+		capturedSubjectToken = form.Get("subject_token")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(tokenExchangeResponse{AccessToken: testAccessToken})
+	}))
+	defer server.Close()
+
+	tokenFile := writeTokenFile(t, "")
+	provider := NewTokenExchangeProvider(tokenFile,
+		WithTokenExchangeUrl(server.URL),
+		WithHttpClient(&http.Client{}),
+	)
+
+	_, err := provider.GetToken(t.Context(), testScope, testParticipantContext)
+	require.NoError(t, err)
+	assert.Equal(t, "", capturedSubjectToken)
+}
+
+func TestGetToken_ContentTypeHeader(t *testing.T) {
+	var capturedContentType string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedContentType = r.Header.Get("Content-Type")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(tokenExchangeResponse{AccessToken: testAccessToken})
+	}))
+	defer server.Close()
+
+	tokenFile := writeTokenFile(t, testSubjectToken)
+	provider := NewTokenExchangeProvider(tokenFile,
+		WithTokenExchangeUrl(server.URL),
+		WithHttpClient(&http.Client{}),
+	)
+
+	_, err := provider.GetToken(t.Context(), testScope, testParticipantContext)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(capturedContentType, "application/x-www-form-urlencoded"))
+}
+
+func TestNewTokenExchangeProvider_DefaultsNoopMonitor(t *testing.T) {
+	provider := NewTokenExchangeProvider("/some/path")
+	assert.NotNil(t, provider.monitor)
+}
+
+func TestGetToken_TokenAppendedToUrl(t *testing.T) {
+	var capturedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(tokenExchangeResponse{AccessToken: testAccessToken})
+	}))
+	defer server.Close()
+
+	tokenFile := writeTokenFile(t, testSubjectToken)
+	provider := NewTokenExchangeProvider(tokenFile,
+		WithTokenExchangeUrl(server.URL),
+		WithHttpClient(&http.Client{}),
+	)
+
+	_, err := provider.GetToken(t.Context(), testScope, testParticipantContext)
+	require.NoError(t, err)
+	assert.Equal(t, "/token", capturedPath)
+}

--- a/docker/Dockerfile.jwtletagent.dockerfile
+++ b/docker/Dockerfile.jwtletagent.dockerfile
@@ -21,13 +21,13 @@ RUN go mod download
 
 COPY . .
 
-# Build the server binary
+# Build the agent binary
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
-    go build -ldflags="-s -w" -o bin/testagent ./e2e/testagent/main.go
+    go build -ldflags="-s -w" -o bin/jwtletagent ./agent/jwtlet-agent/cmd/server/main.go
 
 # Production stage
 FROM gcr.io/distroless/static-debian12:nonroot
 
-COPY --from=builder /app/bin/testagent /testagent
+COPY --from=builder /app/bin/jwtletagent /jwtletagent
 
-ENTRYPOINT ["/testagent"]
+ENTRYPOINT ["/jwtletagent"]


### PR DESCRIPTION
## Summary

- Adds a new `jwtlet-agent` that manages resource and scope mappings in jwtlet, enabling token-exchange-based authentication for participant contexts
- Introduces a shared `TokenExchangeProvider` in `common/tokenexchange` that reads a workload identity token from a file share (Kubernetes projected ServiceAccount token) and exchanges it for a participant-context-bound token via jwtlet
- Migrates all existing agents (EDC-v, IH, onboarding, registration, keycloak) from their previous token provider implementations to the new shared `TokenExchangeProvider`
- Switches from combined scope strings to granular per-scope entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)