### PR TITLE
feat(agent): use fully-qualified API scopes and centralize agent scope set

### DIFF
--- a/agent/common/controlplane/controlplane.go
+++ b/agent/common/controlplane/controlplane.go
@@ -33,9 +33,11 @@ const (
 	ParticipantContextStateActivated   ParticipantContextState = "ACTIVATED"
 	ParticipantContextStateDeactivated ParticipantContextState = "DEACTIVATED"
 	contextConnector                                           = "https://w3id.org/edc/connector/management/v2"
-	ScopeApiWrite                                              = "write"
-	ScopeApiRead                                               = "read"
-	ScopeApiAdmin                                              = "admin"
+	ScopeApiWrite                                              = "management-api:write"
+	ScopeApiRead                                               = "management-api:read"
+	// ScopeApiAdmin is required for participant context lifecycle operations: they act on
+	// participant contexts other than the token's own subject, which only admin may do.
+	ScopeApiAdmin = "management-api:admin"
 )
 
 type ParticipantContextConfig struct {

--- a/agent/common/identityhub/identityhub.go
+++ b/agent/common/identityhub/identityhub.go
@@ -31,9 +31,11 @@ const (
 	CredentialRequestStateCreated = "CREATED"
 	CredentialRequestStateIssued  = "ISSUED"
 	CredentialRequestStateError   = "ERROR"
-	ScopeApiRead                  = "read"
-	ScopeApiWrite                 = "write"
-	ScopeApiAdmin                 = "admin"
+	ScopeCredentialsRead          = "identity-api:credentials:read"
+	ScopeCredentialsWrite         = "identity-api:credentials:write"
+	// ScopeApiAdmin is required for participant context creation/deletion: these act on
+	// participant contexts other than the token's own subject, which only admin may do.
+	ScopeApiAdmin = "identity-api:admin"
 )
 
 type IdentityAPIClient interface {
@@ -80,7 +82,7 @@ func (a HttpIdentityAPIClient) DeleteParticipantContext(ctx context.Context, par
 
 func (a HttpIdentityAPIClient) QueryCredentialByType(ctx context.Context, participantContextID string, credentialType string) ([]common.VerifiableCredentialResource, error) {
 
-	accessToken, err := a.TokenProvider.GetToken(ctx, ScopeApiRead, participantContextID)
+	accessToken, err := a.TokenProvider.GetToken(ctx, ScopeCredentialsRead, participantContextID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get API access token: %w", err)
 	}
@@ -114,7 +116,7 @@ func (a HttpIdentityAPIClient) QueryCredentialByType(ctx context.Context, partic
 }
 
 func (a HttpIdentityAPIClient) RequestCredentials(ctx context.Context, participantContextID string, credentialRequest CredentialRequest) (string, error) {
-	accessToken, err := a.TokenProvider.GetToken(ctx, ScopeApiWrite, participantContextID) // this should be the participant context's access token!
+	accessToken, err := a.TokenProvider.GetToken(ctx, ScopeCredentialsWrite, participantContextID) // this should be the participant context's access token!
 	if err != nil {
 		return "", fmt.Errorf("failed to get API access token: %w", err)
 	}
@@ -151,7 +153,7 @@ func (a HttpIdentityAPIClient) RequestCredentials(ctx context.Context, participa
 }
 
 func (a HttpIdentityAPIClient) GetCredentialRequestState(ctx context.Context, participantContextID string, credentialRequestID string) (string, error) {
-	accessToken, err := a.TokenProvider.GetToken(ctx, ScopeApiRead, participantContextID)
+	accessToken, err := a.TokenProvider.GetToken(ctx, ScopeCredentialsRead, participantContextID)
 	if err != nil {
 		return "", fmt.Errorf("failed to get API access token: %w", err)
 	}

--- a/agent/common/issuerservice/issuer.go
+++ b/agent/common/issuerservice/issuer.go
@@ -27,9 +27,12 @@ import (
 )
 
 const (
-	ScopeApiRead  = "read"
-	ScopeApiWrite = "write"
-	ScopeApiAdmin = "admin"
+	// ScopeApiAdmin is required for all issuer-admin-api operations here: the token is bound
+	// to the tenant's participant context, which the IssuerService does not know (it only has
+	// the issuer's context), so the caller resolution only passes with admin. Resource-level
+	// scopes (e.g. issuer-admin-api:credentials:read) are rejected with
+	// "No participant for 'sub = ...' found".
+	ScopeApiAdmin = "issuer-admin-api:admin"
 )
 
 // IssuerCredentialResourceDto represents a DTO for verifiable credentials that the IssuerService has issued to holders.
@@ -57,7 +60,7 @@ type HttpApiClient struct {
 }
 
 func (i HttpApiClient) QueryCredentialsByType(ctx context.Context, holderID string, credentialType string) ([]IssuerCredentialResourceDto, error) {
-	accessToken, err := i.TokenProvider.GetToken(ctx, ScopeApiRead, holderID)
+	accessToken, err := i.TokenProvider.GetToken(ctx, ScopeApiAdmin, holderID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get API access token: %w", err)
 	}
@@ -186,7 +189,7 @@ func (i HttpApiClient) CreateHolder(ctx context.Context, participantContextID st
 }
 
 func (i HttpApiClient) RevokeCredential(ctx context.Context, participantContextID string, credentialID string) error {
-	accessToken, err := i.TokenProvider.GetToken(ctx, ScopeApiWrite, participantContextID)
+	accessToken, err := i.TokenProvider.GetToken(ctx, ScopeApiAdmin, participantContextID)
 	if err != nil {
 		return err
 	}

--- a/agent/lifecycle/keymanagementagent/siglet/siglet_api_client.go
+++ b/agent/lifecycle/keymanagementagent/siglet/siglet_api_client.go
@@ -26,8 +26,8 @@ import (
 )
 
 const (
-	ScopeApiRead  = "siglet-read"
-	ScopeApiWrite = "siglet-write"
+	ScopeApiRead  = "siglet-mgmt-api:read"
+	ScopeApiWrite = "siglet-mgmt-api:write"
 )
 
 type KeyMapping struct {

--- a/agent/orchestration/jwtletagent/activity/activity.go
+++ b/agent/orchestration/jwtletagent/activity/activity.go
@@ -24,6 +24,10 @@ import (
 	"os"
 	"strings"
 
+	"github.com/eclipse-cfm/cfm/agent/common/controlplane"
+	"github.com/eclipse-cfm/cfm/agent/common/identityhub"
+	"github.com/eclipse-cfm/cfm/agent/common/issuerservice"
+	"github.com/eclipse-cfm/cfm/agent/lifecycle/keymanagementagent/siglet"
 	"github.com/eclipse-cfm/cfm/common/system"
 	"github.com/eclipse-cfm/cfm/common/token"
 	"github.com/eclipse-cfm/cfm/pmanager/api"
@@ -47,6 +51,21 @@ const (
 var vaultClientIdentifiers = []string{
 	"system:serviceaccount:edc-v:controlplane",
 	"system:serviceaccount:edc-v:identityhub",
+}
+
+// agentScopes is the exact set of narrow scopes the CFM agents request against a participant
+// context, referenced from the API clients so the mapping cannot drift from what they request.
+// Every scope listed here must have a (1:1) scope mapping seeded in jwtlet.
+var agentScopes = []string{
+	controlplane.ScopeApiAdmin,
+	identityhub.ScopeApiAdmin,
+	identityhub.ScopeCredentialsRead,
+	identityhub.ScopeCredentialsWrite,
+	issuerservice.ScopeApiAdmin,
+	siglet.ScopeApiRead,
+	siglet.ScopeApiWrite,
+	"read",
+	"write",
 }
 
 type TokenExchangeActivityProcessor struct {
@@ -118,7 +137,7 @@ func (p TokenExchangeActivityProcessor) ProcessDeploy(ctx api.ActivityContext) a
 	rm := resourceMapping{
 		ClientIdentifier:   clientIdentifier,
 		ParticipantContext: participantContextID,
-		Scopes:             []string{"read", "write", "admin", "siglet-read", "siglet-write"},
+		Scopes:             agentScopes,
 		Audiences:          []string{p.Audience},
 	}
 	p.Monitor.Debugf("Creating resource mapping for participant context: %s", participantContextID)
@@ -148,10 +167,12 @@ func (p TokenExchangeActivityProcessor) ProcessDeploy(ctx api.ActivityContext) a
 	mapSpan.AddEvent("Created vault resource mappings")
 	mapSpan.End()
 
-	// step 2: verify the token exchange works for the new participant context
+	// step 2: verify the token exchange works for the new participant context. Requesting the
+	// full agent scope set also proves that every scope has a scope mapping seeded in jwtlet,
+	// so a missing mapping fails here instead of in a downstream agent.
 	exCtx, exSpan := p.tracer.Start(spanCtx, "cfm.agent.jwtlet.deploy.verify-token-exchange", trace.WithSpanKind(trace.SpanKindClient))
 	p.Monitor.Debugf("testing token exchange for participant context: %s", participantContextID)
-	scopedToken, err := p.TokenProvider.GetToken(exCtx, "read write", participantContextID)
+	scopedToken, err := p.TokenProvider.GetToken(exCtx, strings.Join(agentScopes, " "), participantContextID)
 	if err != nil {
 		exSpan.RecordError(err)
 		exSpan.End()

--- a/agent/orchestration/jwtletagent/activity/activity_test.go
+++ b/agent/orchestration/jwtletagent/activity/activity_test.go
@@ -1,0 +1,109 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package activity
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eclipse-cfm/cfm/common/system"
+	"github.com/eclipse-cfm/cfm/pmanager/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTokenProvider records the scope it was asked for and returns a canned token/error.
+type fakeTokenProvider struct {
+	requestedScopes []string
+	token           string
+	err             error
+}
+
+func (f *fakeTokenProvider) GetToken(_ context.Context, scope string, _ string) (string, error) {
+	f.requestedScopes = append(f.requestedScopes, scope)
+	return f.token, f.err
+}
+
+// stubToken is a syntactically valid JWT (header.payload.signature) whose payload decodes to JSON,
+// so decodeJWTClaims accepts it.
+func stubToken() string {
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"participant-123"}`))
+	return "header." + payload + ".signature"
+}
+
+func newProcessorForTest(t *testing.T, tp *fakeTokenProvider, mappingsBase string) *TokenExchangeActivityProcessor {
+	t.Helper()
+	tokenFile := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("workload-token"), 0o600))
+
+	return NewProcessor(&Config{
+		LogMonitor:         system.NoopMonitor{},
+		TokenProvider:      tp,
+		HttpClient:         http.DefaultClient,
+		ManagementBasePath: mappingsBase,
+		TokenFilePath:      tokenFile,
+		Audience:           "test-audience",
+	})
+}
+
+func newDeployContext() api.ActivityContext {
+	processingData := map[string]any{"cfm.participant.id": "participant-123"}
+	return api.NewActivityContext(context.Background(), "orch-1", api.Activity{}, processingData, map[string]any{})
+}
+
+// TestProcessDeploy_VerifiesFullAgentScopeSet asserts that the token-exchange verification step
+// requests exactly the agentScopes set (space-joined), which is what proves every scope has a
+// mapping seeded in jwtlet.
+func TestProcessDeploy_VerifiesFullAgentScopeSet(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tp := &fakeTokenProvider{token: stubToken()}
+	processor := newProcessorForTest(t, tp, server.URL)
+
+	result := processor.ProcessDeploy(newDeployContext())
+
+	require.EqualValues(t, api.ActivityResultComplete, result.Result, "expected deploy to complete, got error: %v", result.Error)
+	require.Len(t, tp.requestedScopes, 1, "token exchange verification should request a token exactly once")
+	assert.Equal(t, strings.Join(agentScopes, " "), tp.requestedScopes[0])
+}
+
+// TestProcessDeploy_FailsWhenScopeHasNoMapping asserts that if the token exchange fails — e.g.
+// because a requested scope has no mapping seeded in jwtlet — deploy fails fast with a fatal error
+// rather than completing and leaving the participant context broken for downstream agents.
+func TestProcessDeploy_FailsWhenScopeHasNoMapping(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tp := &fakeTokenProvider{err: assert.AnError}
+	processor := newProcessorForTest(t, tp, server.URL)
+
+	result := processor.ProcessDeploy(newDeployContext())
+
+	require.EqualValues(t, api.ActivityResultFatalError, result.Result)
+	require.Error(t, result.Error)
+	assert.Contains(t, result.Error.Error(), "token exchange")
+	assert.Equal(t, strings.Join(agentScopes, " "), tp.requestedScopes[0])
+}


### PR DESCRIPTION
## Summary

Replaces the short scope constants (`read`/`write`/`admin`, `siglet-read`/`siglet-write`) with their fully-qualified equivalents so the agents request the scopes the services actually enforce, and centralizes the agent scope set in the jwtlet activity so seeded scope mappings cannot drift from what the clients request.

## Changes

- **controlplane**: scopes become `management-api:{read,write,admin}`. Participant context lifecycle operations require `management-api:admin`.
- **identityhub**: credential operations use resource-scoped `identity-api:credentials:{read,write}`; participant context create/delete still require `identity-api:admin`.
- **issuerservice**: all operations require `issuer-admin-api:admin` — the token is bound to the issuer's participant context, so resource-level scopes are rejected with `No participant for 'sub = ...' found`.
- **siglet**: scopes become `siglet-mgmt-api:{read,write}`.
- **jwtlet activity**: introduces `agentScopes`, sourced directly from the API client constants. The deploy-time token-exchange verification now requests the full set, so a missing scope mapping fails fast at deploy rather than in a downstream agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)