### PR TITLE
feat: avoid provisioning the api key for IH

### DIFF
--- a/agent/common/identityhub/identityhub.go
+++ b/agent/common/identityhub/identityhub.go
@@ -200,6 +200,7 @@ func (a HttpIdentityAPIClient) CreateParticipantContext(ctx context.Context, man
 	data := map[string]any{
 		"roles":               []string{"participant"},
 		"provisionStsAccount": manifest.ProvisionStsAccount,
+		"provisionApiKey":     manifest.ProvisionApiKey,
 		"serviceEndpoints": []map[string]any{
 			{
 				"type":            "CredentialService",

--- a/agent/common/identityhub/identityhub_test.go
+++ b/agent/common/identityhub/identityhub_test.go
@@ -43,6 +43,7 @@ func TestIdentityAPIClient_CreateParticipantContext(t *testing.T) {
 			require.Equal(t, "did:web:test", data["did"])
 			require.True(t, data["active"].(bool))
 			require.False(t, data["provisionStsAccount"].(bool))
+			require.False(t, data["provisionApiKey"].(bool))
 
 			serviceEndpoints := data["serviceEndpoints"].([]any)
 			require.Len(t, serviceEndpoints, 3)

--- a/agent/common/identityhub/types.go
+++ b/agent/common/identityhub/types.go
@@ -65,6 +65,8 @@ type ParticipantManifest struct {
 	VaultConfig commonvault.Config
 	// ProvisionStsAccount indicates whether IdentityHub should provision an STS account for the participant. Defaults to false.
 	ProvisionStsAccount bool
+	// ProvisionApiKey indicates whether IdentityHub should provision an API key for the participant. Defaults to false.
+	ProvisionApiKey bool
 }
 
 type ParticipantManifestOptions func(*ParticipantManifest)

--- a/agent/common/identityhub/types_test.go
+++ b/agent/common/identityhub/types_test.go
@@ -34,6 +34,8 @@ func TestNewParticipantManifest_WithDefaults(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, manifest.VaultConfig.SecretPath, "v1/participants")
 	require.Equal(t, manifest.VaultConfig.FolderPath, "test-id/identityhub")
+	require.False(t, manifest.ProvisionStsAccount)
+	require.False(t, manifest.ProvisionApiKey)
 }
 
 func TestParticipantManifest_Serialization(t *testing.T) {

--- a/agent/orchestration/edcv/activity/activity.go
+++ b/agent/orchestration/edcv/activity/activity.go
@@ -98,7 +98,7 @@ func (p EDCVActivityProcessor) handleDeployAction(ctx api.ActivityContext, data 
 	vaultConfig := edcv.VaultConfig{
 		VaultURL:   p.VaultURL,
 		SecretPath: "v1/participants",
-		FolderPath: participantContextId + "/identityhub",
+		FolderPath: participantContextId + "/controlplane",
 	}
 
 	_, ctrl := p.tracer.Start(ctx.Context(), "cfm.agent.edcv.deploy.controlplane", trace.WithSpanKind(trace.SpanKindClient))


### PR DESCRIPTION
avoid provisioning the api key for IH

Additionally changed the vault path for EDC-V participant from

`{participantId}/identityhub` -> `{participantId}/controlplane`