### PR TITLE
feat: support authenticated NATS connections

### DIFF
--- a/common/lifecycleagent/agent.go
+++ b/common/lifecycleagent/agent.go
@@ -30,8 +30,7 @@ const timeout = 10 * time.Second
 // dispatches it to the agent's EventProcessor.
 type eventAgentServiceAssembly[T any] struct {
 	agentName    string
-	uri          string
-	bucket       string
+	clientConfig natsclient.ClientConfig
 	streamName   string
 	subjects     []string
 	newProcessor func(ctx *AgentContext) EventProcessor[T]
@@ -52,7 +51,7 @@ func (a *eventAgentServiceAssembly[T]) Requires() []system.ServiceType {
 
 func (a *eventAgentServiceAssembly[T]) Start(startCtx *system.StartContext) error {
 	var err error
-	a.natsClient, err = natsclient.NewNatsClient(a.uri, a.bucket)
+	a.natsClient, err = natsclient.NewNatsClient(a.clientConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create NATS client: %w", err)
 	}

--- a/common/lifecycleagent/launcher.go
+++ b/common/lifecycleagent/launcher.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/eclipse-cfm/cfm/common/natsclient"
 	"github.com/eclipse-cfm/cfm/common/runtime"
 	"github.com/eclipse-cfm/cfm/common/system"
 	"github.com/nats-io/nats.go"
@@ -84,12 +85,11 @@ type LauncherConfig[T any] struct {
 }
 
 type agentConfig struct {
-	Name       string
-	URI        string
-	Bucket     string
-	StreamName string
-	Subjects   []string
-	VConfig    *viper.Viper
+	Name         string
+	ClientConfig natsclient.ClientConfig
+	StreamName   string
+	Subjects     []string
+	VConfig      *viper.Viper
 }
 
 // LaunchAgent bootstraps and runs a lifecycle agent until the shutdown channel is closed.
@@ -116,8 +116,7 @@ func LaunchAgent[T any](shutdown <-chan struct{}, config LauncherConfig[T]) {
 
 	agentAssembly := &eventAgentServiceAssembly[T]{
 		agentName:    config.AgentName,
-		uri:          cfg.URI,
-		bucket:       cfg.Bucket,
+		clientConfig: cfg.ClientConfig,
 		streamName:   cfg.StreamName,
 		subjects:     cfg.Subjects,
 		newProcessor: config.NewProcessor,
@@ -154,13 +153,17 @@ func loadAgentConfig(name string, configPrefix string, defaultSubjects []string)
 		panic(fmt.Errorf("error loading agent configuration: at least one subject must be configured via LauncherConfig.Subjects, %s.%s or %s.%s", configPrefix, subjectsKey, configPrefix, subjectKey))
 	}
 
+	auth, err := natsclient.AuthFromConfig(vConfig)
+	if err != nil {
+		panic(fmt.Errorf("error loading agent configuration: %w", err))
+	}
+
 	return &agentConfig{
-		Name:       name,
-		URI:        uri,
-		Bucket:     bucketValue,
-		StreamName: streamValue,
-		Subjects:   subjects,
-		VConfig:    vConfig,
+		Name:         name,
+		ClientConfig: natsclient.ClientConfig{URL: uri, Bucket: bucketValue, Auth: auth},
+		StreamName:   streamValue,
+		Subjects:     subjects,
+		VConfig:      vConfig,
 	}
 }
 

--- a/common/natsclient/auth.go
+++ b/common/natsclient/auth.go
@@ -1,0 +1,128 @@
+//  Copyright (c) 2026 Metaform Systems, Inc
+//
+//  This program and the accompanying materials are made available under the
+//  terms of the Apache License, Version 2.0 which is available at
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  SPDX-License-Identifier: Apache-2.0
+//
+//  Contributors:
+//       Metaform Systems, Inc. - initial API and implementation
+//
+
+package natsclient
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/nats-io/nats.go"
+	"github.com/spf13/viper"
+)
+
+// Configuration keys for NATS authentication, relative to the component's configuration prefix. With the standard
+// environment variable mapping they translate to e.g. PM_NATS_AUTH_METHOD for the Provision Manager.
+const (
+	AuthMethodKey       = "nats.auth.method"
+	AuthUsernameKey     = "nats.auth.username"
+	AuthPasswordKey     = "nats.auth.password"
+	AuthTokenKey        = "nats.auth.token"
+	AuthNKeySeedFileKey = "nats.auth.nkeySeedFile"
+	AuthCredsFileKey    = "nats.auth.credsFile"
+)
+
+// Supported values for AuthMethodKey.
+const (
+	AuthMethodNone        = "none"
+	AuthMethodUserInfo    = "userinfo"
+	AuthMethodToken       = "token"
+	AuthMethodNKey        = "nkey"
+	AuthMethodCredentials = "credentials"
+)
+
+// AuthStrategy produces the nats.Option set for one authentication mechanism. Implementations validate their inputs
+// so that misconfiguration fails at startup instead of surfacing as an opaque connection error.
+type AuthStrategy interface {
+	Options() ([]nats.Option, error)
+}
+
+// UserInfoAuth authenticates with a username and password.
+type UserInfoAuth struct {
+	Username string
+	Password string
+}
+
+func (a UserInfoAuth) Options() ([]nats.Option, error) {
+	if a.Username == "" || a.Password == "" {
+		return nil, fmt.Errorf("user/password authentication requires %s and %s to be set", AuthUsernameKey, AuthPasswordKey)
+	}
+	return []nats.Option{nats.UserInfo(a.Username, a.Password)}, nil
+}
+
+// TokenAuth authenticates with a static token.
+type TokenAuth struct {
+	Token string
+}
+
+func (a TokenAuth) Options() ([]nats.Option, error) {
+	if a.Token == "" {
+		return nil, fmt.Errorf("token authentication requires %s to be set", AuthTokenKey)
+	}
+	return []nats.Option{nats.Token(a.Token)}, nil
+}
+
+// NKeyAuth authenticates by signing the server nonce with the NKey seed read from SeedFile.
+type NKeyAuth struct {
+	SeedFile string
+}
+
+func (a NKeyAuth) Options() ([]nats.Option, error) {
+	if a.SeedFile == "" {
+		return nil, fmt.Errorf("NKey authentication requires %s to be set", AuthNKeySeedFileKey)
+	}
+	option, err := nats.NkeyOptionFromSeed(a.SeedFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load NKey seed file %s: %w", a.SeedFile, err)
+	}
+	return []nats.Option{option}, nil
+}
+
+// CredentialsAuth authenticates with a JWT and NKey credentials file, used by decentralized (operator-mode) NATS
+// deployments.
+type CredentialsAuth struct {
+	CredsFile string
+}
+
+func (a CredentialsAuth) Options() ([]nats.Option, error) {
+	if a.CredsFile == "" {
+		return nil, fmt.Errorf("credentials authentication requires %s to be set", AuthCredsFileKey)
+	}
+	// nats.UserCredentials reads the file lazily on connect, so check readability here to fail fast
+	if _, err := os.Stat(a.CredsFile); err != nil {
+		return nil, fmt.Errorf("failed to read credentials file %s: %w", a.CredsFile, err)
+	}
+	return []nats.Option{nats.UserCredentials(a.CredsFile)}, nil
+}
+
+// AuthFromConfig resolves the AuthStrategy from configuration. It returns nil when no authentication is configured
+// (AuthMethodKey unset or "none"), which preserves anonymous connections. Value validation is deferred to
+// AuthStrategy.Options so that all strategies report configuration errors uniformly.
+func AuthFromConfig(v *viper.Viper) (AuthStrategy, error) {
+	method := strings.ToLower(v.GetString(AuthMethodKey))
+	switch method {
+	case "", AuthMethodNone:
+		return nil, nil
+	case AuthMethodUserInfo:
+		return UserInfoAuth{Username: v.GetString(AuthUsernameKey), Password: v.GetString(AuthPasswordKey)}, nil
+	case AuthMethodToken:
+		return TokenAuth{Token: v.GetString(AuthTokenKey)}, nil
+	case AuthMethodNKey:
+		return NKeyAuth{SeedFile: v.GetString(AuthNKeySeedFileKey)}, nil
+	case AuthMethodCredentials:
+		return CredentialsAuth{CredsFile: v.GetString(AuthCredsFileKey)}, nil
+	default:
+		return nil, fmt.Errorf("unsupported NATS authentication method %q: must be one of %s, %s, %s, %s or %s",
+			method, AuthMethodNone, AuthMethodUserInfo, AuthMethodToken, AuthMethodNKey, AuthMethodCredentials)
+	}
+}

--- a/common/natsclient/auth_integration_test.go
+++ b/common/natsclient/auth_integration_test.go
@@ -1,0 +1,132 @@
+//  Copyright (c) 2026 Metaform Systems, Inc
+//
+//  This program and the accompanying materials are made available under the
+//  terms of the Apache License, Version 2.0 which is available at
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  SPDX-License-Identifier: Apache-2.0
+//
+//  Contributors:
+//       Metaform Systems, Inc. - initial API and implementation
+//
+
+package natsclient_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/eclipse-cfm/cfm/common/natsclient"
+	"github.com/eclipse-cfm/cfm/common/natsfixtures"
+	"github.com/nats-io/nkeys"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const authTestTimeout = 60 * time.Second
+
+// verifyKVRoundTrip asserts that the authenticated client is fully functional by writing and reading a KV entry.
+func verifyKVRoundTrip(t *testing.T, ctx context.Context, client *natsclient.NatsClient) {
+	t.Helper()
+	_, err := client.KVStore.Put(ctx, "auth-test-key", []byte("auth-test-value"))
+	require.NoError(t, err)
+	entry, err := client.KVStore.Get(ctx, "auth-test-key")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("auth-test-value"), entry.Value())
+}
+
+func TestNatsClient_TokenAuth(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), authTestTimeout)
+	defer cancel()
+
+	nt, err := natsfixtures.SetupNatsContainerWithAuth(ctx, "cfm-bucket",
+		`authorization { token: "s3cret" }`,
+		natsclient.TokenAuth{Token: "s3cret"})
+	require.NoError(t, err)
+	defer natsfixtures.TeardownNatsContainer(ctx, nt)
+
+	verifyKVRoundTrip(t, ctx, nt.Client)
+}
+
+func TestNatsClient_TokenAuth_WrongToken(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), authTestTimeout)
+	defer cancel()
+
+	_, err := natsfixtures.SetupNatsContainerWithAuth(ctx, "cfm-bucket",
+		`authorization { token: "s3cret" }`,
+		natsclient.TokenAuth{Token: "wrong"})
+	require.Error(t, err)
+}
+
+func TestNatsClient_UserInfoAuth(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), authTestTimeout)
+	defer cancel()
+
+	nt, err := natsfixtures.SetupNatsContainerWithAuth(ctx, "cfm-bucket",
+		`authorization { user: "cfm", password: "s3cret" }`,
+		natsclient.UserInfoAuth{Username: "cfm", Password: "s3cret"})
+	require.NoError(t, err)
+	defer natsfixtures.TeardownNatsContainer(ctx, nt)
+
+	verifyKVRoundTrip(t, ctx, nt.Client)
+}
+
+func TestNatsClient_UserInfoAuth_WrongCreds(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), authTestTimeout)
+	defer cancel()
+
+	_, err := natsfixtures.SetupNatsContainerWithAuth(ctx, "cfm-bucket",
+		`authorization { user: "cfm", password: "s3cret" }`,
+		natsclient.UserInfoAuth{Username: "cfm", Password: "wrong_pwd"})
+	require.Errorf(t, err, "foobar")
+}
+
+func TestNatsClient_NKeyAuth(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), authTestTimeout)
+	defer cancel()
+
+	keyPair, err := nkeys.CreateUser()
+	require.NoError(t, err)
+	publicKey, err := keyPair.PublicKey()
+	require.NoError(t, err)
+	seed, err := keyPair.Seed()
+	require.NoError(t, err)
+	seedFile := filepath.Join(t.TempDir(), "user.nk")
+	require.NoError(t, os.WriteFile(seedFile, seed, 0600))
+
+	nt, err := natsfixtures.SetupNatsContainerWithAuth(ctx, "cfm-bucket",
+		fmt.Sprintf(`authorization { users = [ { nkey: "%s" } ] }`, publicKey),
+		natsclient.NKeyAuth{SeedFile: seedFile})
+	require.NoError(t, err)
+	defer natsfixtures.TeardownNatsContainer(ctx, nt)
+
+	verifyKVRoundTrip(t, ctx, nt.Client)
+}
+
+func TestNatsClient_NKeyAuth_InvalidSeed(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), authTestTimeout)
+	defer cancel()
+
+	// create key pair for the user server side
+	serverSideUser, err := nkeys.CreateUser()
+	require.NoError(t, err)
+	publicKey, err := serverSideUser.PublicKey()
+	require.NoError(t, err)
+
+	// create DIFFERENT key pair for the user, client side
+	clientSideUser, err := nkeys.CreateUser()
+	require.NoError(t, err)
+	seed, err := clientSideUser.Seed()
+	require.NoError(t, err)
+	seedFile := filepath.Join(t.TempDir(), "user.nk")
+	require.NoError(t, os.WriteFile(seedFile, seed, 0600))
+
+	_, err = natsfixtures.SetupNatsContainerWithAuth(ctx, "cfm-bucket",
+		fmt.Sprintf(`authorization { users = [ { nkey: "%s" } ] }`, publicKey),
+		natsclient.NKeyAuth{SeedFile: seedFile})
+	require.Errorf(t, err, "invalid seed file")
+}

--- a/common/natsclient/auth_test.go
+++ b/common/natsclient/auth_test.go
@@ -1,0 +1,138 @@
+//  Copyright (c) 2026 Metaform Systems, Inc
+//
+//  This program and the accompanying materials are made available under the
+//  terms of the Apache License, Version 2.0 which is available at
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  SPDX-License-Identifier: Apache-2.0
+//
+//  Contributors:
+//       Metaform Systems, Inc. - initial API and implementation
+//
+
+package natsclient
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nats-io/nkeys"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserInfoAuth_Options(t *testing.T) {
+	options, err := UserInfoAuth{Username: "user", Password: "pass"}.Options()
+	require.NoError(t, err)
+	assert.Len(t, options, 1)
+
+	_, err = UserInfoAuth{Username: "user"}.Options()
+	assert.ErrorContains(t, err, AuthPasswordKey)
+
+	_, err = UserInfoAuth{Password: "pass"}.Options()
+	assert.ErrorContains(t, err, AuthUsernameKey)
+}
+
+func TestTokenAuth_Options(t *testing.T) {
+	options, err := TokenAuth{Token: "s3cret"}.Options()
+	require.NoError(t, err)
+	assert.Len(t, options, 1)
+
+	_, err = TokenAuth{}.Options()
+	assert.ErrorContains(t, err, AuthTokenKey)
+}
+
+func TestNKeyAuth_Options(t *testing.T) {
+	options, err := NKeyAuth{SeedFile: writeNKeySeedFile(t)}.Options()
+	require.NoError(t, err)
+	assert.Len(t, options, 1)
+
+	_, err = NKeyAuth{}.Options()
+	assert.ErrorContains(t, err, AuthNKeySeedFileKey)
+
+	_, err = NKeyAuth{SeedFile: filepath.Join(t.TempDir(), "missing.nk")}.Options()
+	assert.ErrorContains(t, err, "failed to load NKey seed file")
+}
+
+func TestCredentialsAuth_Options(t *testing.T) {
+	credsFile := filepath.Join(t.TempDir(), "user.creds")
+	require.NoError(t, os.WriteFile(credsFile, []byte("-----BEGIN NATS USER JWT-----"), 0600))
+
+	options, err := CredentialsAuth{CredsFile: credsFile}.Options()
+	require.NoError(t, err)
+	assert.Len(t, options, 1)
+
+	_, err = CredentialsAuth{}.Options()
+	assert.ErrorContains(t, err, AuthCredsFileKey)
+
+	_, err = CredentialsAuth{CredsFile: filepath.Join(t.TempDir(), "missing.creds")}.Options()
+	assert.ErrorContains(t, err, "failed to read credentials file")
+}
+
+func TestAuthFromConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings map[string]string
+		expected AuthStrategy
+	}{
+		{name: "unset defaults to anonymous", settings: nil, expected: nil},
+		{name: "none", settings: map[string]string{AuthMethodKey: "none"}, expected: nil},
+		{
+			name:     "userinfo",
+			settings: map[string]string{AuthMethodKey: "userinfo", AuthUsernameKey: "user", AuthPasswordKey: "pass"},
+			expected: UserInfoAuth{Username: "user", Password: "pass"},
+		},
+		{
+			name:     "method is case-insensitive",
+			settings: map[string]string{AuthMethodKey: "UserInfo", AuthUsernameKey: "user", AuthPasswordKey: "pass"},
+			expected: UserInfoAuth{Username: "user", Password: "pass"},
+		},
+		{
+			name:     "token",
+			settings: map[string]string{AuthMethodKey: "token", AuthTokenKey: "s3cret"},
+			expected: TokenAuth{Token: "s3cret"},
+		},
+		{
+			name:     "nkey",
+			settings: map[string]string{AuthMethodKey: "nkey", AuthNKeySeedFileKey: "/etc/nats/user.nk"},
+			expected: NKeyAuth{SeedFile: "/etc/nats/user.nk"},
+		},
+		{
+			name:     "credentials",
+			settings: map[string]string{AuthMethodKey: "credentials", AuthCredsFileKey: "/etc/nats/user.creds"},
+			expected: CredentialsAuth{CredsFile: "/etc/nats/user.creds"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := viper.New()
+			for key, value := range tt.settings {
+				v.Set(key, value)
+			}
+			auth, err := AuthFromConfig(v)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, auth)
+		})
+	}
+}
+
+func TestAuthFromConfig_UnsupportedMethod(t *testing.T) {
+	v := viper.New()
+	v.Set(AuthMethodKey, "kerberos")
+	_, err := AuthFromConfig(v)
+	assert.ErrorContains(t, err, `unsupported NATS authentication method "kerberos"`)
+}
+
+// writeNKeySeedFile generates a user NKey pair and writes the seed to a temp file, returning its path.
+func writeNKeySeedFile(t *testing.T) string {
+	t.Helper()
+	keyPair, err := nkeys.CreateUser()
+	require.NoError(t, err)
+	seed, err := keyPair.Seed()
+	require.NoError(t, err)
+	seedFile := filepath.Join(t.TempDir(), "user.nk")
+	require.NoError(t, os.WriteFile(seedFile, seed, 0600))
+	return seedFile
+}

--- a/common/natsclient/nats.go
+++ b/common/natsclient/nats.go
@@ -39,18 +39,38 @@ type NatsClient struct {
 	KVStore    jetstream.KeyValue
 }
 
-// NewNatsClient creates and returns a new NatsClient instance connected to the specified URL and bucket with given options.
-// If options are not provided, default Connection settings are used for the NATS Client configuration.
+// ClientConfig configures a NATS client connection.
+type ClientConfig struct {
+	// URL of the NATS server(s).
+	URL string
+	// Bucket is the JetStream key-value bucket the client operates on.
+	Bucket string
+	// Auth supplies the authentication mechanism; nil connects anonymously.
+	Auth AuthStrategy
+}
+
+// NewNatsClient creates and returns a new NatsClient instance connected according to the given config. Default
+// connection resilience options are always applied; authentication options derived from cfg.Auth and any extra
+// options are appended after them and take precedence.
 // Returns an error if the Connection to NATS or JetStream initialization fails.
-func NewNatsClient(url string, bucket string, options ...nats.Option) (*NatsClient, error) {
-	if options == nil || len(options) == 0 {
-		options = []nats.Option{nats.PingInterval(defaultDuration),
-			nats.MaxPingsOutstanding(defaultPings),
-			nats.ReconnectWait(time.Second),
-			nats.RetryOnFailedConnect(true),
-			nats.MaxReconnects(forever)}
+func NewNatsClient(cfg ClientConfig, extra ...nats.Option) (*NatsClient, error) {
+	options := []nats.Option{
+		nats.PingInterval(defaultDuration),
+		nats.MaxPingsOutstanding(defaultPings),
+		nats.ReconnectWait(time.Second),
+		nats.RetryOnFailedConnect(true),
+		nats.MaxReconnects(forever),
 	}
-	connection, err := nats.Connect(url, options...)
+	if cfg.Auth != nil {
+		authOptions, err := cfg.Auth.Options()
+		if err != nil {
+			return nil, fmt.Errorf("failed to configure NATS authentication: %w", err)
+		}
+		options = append(options, authOptions...)
+	}
+	options = append(options, extra...)
+
+	connection, err := nats.Connect(cfg.URL, options...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to NATS: %w", err)
 	}
@@ -61,10 +81,10 @@ func NewNatsClient(url string, bucket string, options ...nats.Option) (*NatsClie
 		return nil, fmt.Errorf("failed to create jetstream context: %w", err)
 	}
 
-	kvManager, err := jetStream.CreateOrUpdateKeyValue(context.Background(), jetstream.KeyValueConfig{Bucket: bucket})
+	kvManager, err := jetStream.CreateOrUpdateKeyValue(context.Background(), jetstream.KeyValueConfig{Bucket: cfg.Bucket})
 	if err != nil {
 		connection.Close()
-		return nil, fmt.Errorf("failed to create jetstream key value store with bucket %s: %w", bucket, err)
+		return nil, fmt.Errorf("failed to create jetstream key value store with bucket %s: %w", cfg.Bucket, err)
 	}
 
 	return &NatsClient{

--- a/common/natsfixtures/fixtures.go
+++ b/common/natsfixtures/fixtures.go
@@ -36,23 +36,32 @@ type NatsTestContainer struct {
 }
 
 func SetupNatsContainer(ctx context.Context, bucket string) (*NatsTestContainer, error) {
+	return SetupNatsContainerWithAuth(ctx, bucket, "", nil)
+}
+
+// SetupNatsContainerWithAuth starts a NATS container whose server configuration includes the given authorization
+// block (raw NATS server config syntax, e.g. `authorization { token: "s3cret" }`) and connects a client using the
+// given auth strategy. An empty block and nil strategy yield an unauthenticated setup.
+func SetupNatsContainerWithAuth(ctx context.Context, bucket string, authorizationBlock string, auth natsclient.AuthStrategy) (*NatsTestContainer, error) {
 	// Create NATS configuration
 	natsConfig := fmt.Sprintf(`
 		# Basic server configuration
 		port: 4222
 		monitor_port: 8222
-		
+
 		# JetStream configuration
 		jetstream {
 			store_dir: "/tmp/jetstream"
 			max_memory_store: 64MB
 			max_file_store: 512MB
 		}
-		
+
 		# Enable debug/trace
 		debug: true
 		trace: true
-		`)
+
+		%s
+		`, authorizationBlock)
 
 	// Create temporary config file
 	tmpDir, err := os.MkdirTemp("", "nats-config-*")
@@ -106,8 +115,10 @@ func SetupNatsContainer(ctx context.Context, bucket string) (*NatsTestContainer,
 
 	uri := fmt.Sprintf("nats://%s:%s", hostIP, mappedPort.Port())
 
-	natsClient, err := natsclient.NewNatsClient(uri, bucket)
+	natsClient, err := natsclient.NewNatsClient(natsclient.ClientConfig{URL: uri, Bucket: bucket, Auth: auth})
 	if err != nil {
+		// terminate the container so failed connection attempts (e.g. negative auth tests) do not leak containers
+		_ = container.Terminate(ctx)
 		return nil, fmt.Errorf("failed to create NATS client: %w", err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/lib/pq v1.12.3
 	github.com/nats-io/nats.go v1.52.0
+	github.com/nats-io/nkeys v0.4.15
 	github.com/oaswrap/spec v0.5.1
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
@@ -83,7 +84,6 @@ require (
 	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/moby/term v0.5.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/nats-io/nkeys v0.4.15 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/oaswrap/spec-ui v0.2.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/pmanager/cmd/server/launcher/launcher.go
+++ b/pmanager/cmd/server/launcher/launcher.go
@@ -17,6 +17,7 @@ import (
 
 	cfmauth "github.com/eclipse-cfm/cfm/assembly/auth"
 	"github.com/eclipse-cfm/cfm/assembly/routing"
+	"github.com/eclipse-cfm/cfm/common/natsclient"
 	"github.com/eclipse-cfm/cfm/common/runtime"
 	"github.com/eclipse-cfm/cfm/common/store"
 	"github.com/eclipse-cfm/cfm/common/system"
@@ -65,6 +66,11 @@ func Launch(shutdown <-chan struct{}) {
 		panic(fmt.Errorf("error launching Provision Manager: %w", err))
 	}
 
+	natsAuth, err := natsclient.AuthFromConfig(vConfig)
+	if err != nil {
+		panic(fmt.Errorf("error launching Provision Manager: %w", err))
+	}
+
 	assembler := system.NewServiceAssembler(logMonitor, vConfig, mode)
 
 	assembler.Register(&routing.RouterServiceAssembly{})
@@ -78,7 +84,7 @@ func Launch(shutdown <-chan struct{}) {
 		assembler.Register(&memorystore.MemoryStoreServiceAssembly{})
 	}
 
-	assembler.Register(natsorchestration.NewOrchestratorServiceAssembly(uri, bucketValue, streamValue))
+	assembler.Register(natsorchestration.NewOrchestratorServiceAssembly(natsclient.ClientConfig{URL: uri, Bucket: bucketValue, Auth: natsAuth}, streamValue))
 	assembler.Register(natsprovision.NewProvisionServiceAssembly(streamValue))
 	assembler.Register(&core.PMCoreServiceAssembly{})
 

--- a/pmanager/natsagent/agent.go
+++ b/pmanager/natsagent/agent.go
@@ -31,8 +31,7 @@ const (
 type agentServiceAssembly struct {
 	agentName        string
 	activityType     string
-	uri              string
-	bucket           string
+	clientConfig     natsclient.ClientConfig
 	streamName       string
 	assemblyProvider func() []system.ServiceAssembly
 	newProcessor     func(ctx *AgentContext) api.ActivityProcessor
@@ -53,7 +52,7 @@ func (h *agentServiceAssembly) Requires() []system.ServiceType {
 
 func (a *agentServiceAssembly) Start(startCtx *system.StartContext) error {
 	var err error
-	a.natsClient, err = natsclient.NewNatsClient(a.uri, a.bucket)
+	a.natsClient, err = natsclient.NewNatsClient(a.clientConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create NATS client: %w", err)
 	}

--- a/pmanager/natsagent/launcher.go
+++ b/pmanager/natsagent/launcher.go
@@ -15,6 +15,7 @@ package natsagent
 import (
 	"fmt"
 
+	"github.com/eclipse-cfm/cfm/common/natsclient"
 	"github.com/eclipse-cfm/cfm/common/runtime"
 	"github.com/eclipse-cfm/cfm/common/system"
 	"github.com/eclipse-cfm/cfm/pmanager/api"
@@ -48,11 +49,10 @@ type AgentRegistry interface {
 }
 
 type agentConfig struct {
-	Name       string
-	URI        string
-	Bucket     string
-	StreamName string
-	VConfig    *viper.Viper
+	Name         string
+	ClientConfig natsclient.ClientConfig
+	StreamName   string
+	VConfig      *viper.Viper
 }
 
 func LaunchAgent(shutdown <-chan struct{}, config LauncherConfig) {
@@ -79,8 +79,7 @@ func LaunchAgent(shutdown <-chan struct{}, config LauncherConfig) {
 	agentAssembly := &agentServiceAssembly{
 		agentName:        config.AgentName,
 		activityType:     config.ActivityType,
-		uri:              cfg.URI,
-		bucket:           cfg.Bucket,
+		clientConfig:     cfg.ClientConfig,
 		streamName:       cfg.StreamName,
 		newProcessor:     config.NewProcessor,
 		requires:         requires,
@@ -109,11 +108,16 @@ func loadAgentConfig(name string, configPrefix string) *agentConfig {
 	if err != nil {
 		panic(fmt.Errorf("error loading agent configuration: %w", err))
 	}
+
+	auth, err := natsclient.AuthFromConfig(vConfig)
+	if err != nil {
+		panic(fmt.Errorf("error loading agent configuration: %w", err))
+	}
+
 	return &agentConfig{
-		Name:       name,
-		URI:        uri,
-		Bucket:     bucketValue,
-		StreamName: streamValue,
-		VConfig:    vConfig,
+		Name:         name,
+		ClientConfig: natsclient.ClientConfig{URL: uri, Bucket: bucketValue, Auth: auth},
+		StreamName:   streamValue,
+		VConfig:      vConfig,
 	}
 }

--- a/pmanager/natsorchestration/assembly.go
+++ b/pmanager/natsorchestration/assembly.go
@@ -28,20 +28,18 @@ const (
 )
 
 type natsOrchestratorServiceAssembly struct {
-	uri        string
-	bucket     string
-	streamName string
-	natsClient *natsclient.NatsClient
+	clientConfig natsclient.ClientConfig
+	streamName   string
+	natsClient   *natsclient.NatsClient
 	system.DefaultServiceAssembly
 	processCancel context.CancelFunc
 	subscription  *nats.Subscription
 }
 
-func NewOrchestratorServiceAssembly(uri string, bucket string, streamName string) system.ServiceAssembly {
+func NewOrchestratorServiceAssembly(clientConfig natsclient.ClientConfig, streamName string) system.ServiceAssembly {
 	return &natsOrchestratorServiceAssembly{
-		uri:        uri,
-		bucket:     bucket,
-		streamName: streamName,
+		clientConfig: clientConfig,
+		streamName:   streamName,
 	}
 }
 
@@ -58,7 +56,7 @@ func (a *natsOrchestratorServiceAssembly) Requires() []system.ServiceType {
 }
 
 func (a *natsOrchestratorServiceAssembly) Init(ctx *system.InitContext) error {
-	natsClient, err := natsclient.NewNatsClient(a.uri, a.bucket)
+	natsClient, err := natsclient.NewNatsClient(a.clientConfig)
 	if err != nil {
 		return err
 	}
@@ -103,7 +101,7 @@ func (a *natsOrchestratorServiceAssembly) Prepare(ctx *system.InitContext) error
 		definitionManager: definitionManager,
 	}
 	var err error
-	a.subscription, err = a.natsClient.JetStream.Conn().Subscribe("$KV."+a.bucket+".>", func(msg *nats.Msg) {
+	a.subscription, err = a.natsClient.JetStream.Conn().Subscribe("$KV."+a.clientConfig.Bucket+".>", func(msg *nats.Msg) {
 		watcher.onMessage(msg.Data, msg)
 	})
 	return err

--- a/tmanager/cmd/server/launcher/launcher.go
+++ b/tmanager/cmd/server/launcher/launcher.go
@@ -17,6 +17,7 @@ import (
 
 	cfmauth "github.com/eclipse-cfm/cfm/assembly/auth"
 	"github.com/eclipse-cfm/cfm/assembly/routing"
+	"github.com/eclipse-cfm/cfm/common/natsclient"
 	"github.com/eclipse-cfm/cfm/common/runtime"
 	"github.com/eclipse-cfm/cfm/common/store"
 	"github.com/eclipse-cfm/cfm/common/system"
@@ -66,6 +67,11 @@ func Launch(shutdown <-chan struct{}) {
 		panic(fmt.Errorf("error launching Tenant Manager: %w", err))
 	}
 
+	natsAuth, err := natsclient.AuthFromConfig(vConfig)
+	if err != nil {
+		panic(fmt.Errorf("error launching Tenant Manager: %w", err))
+	}
+
 	assembler := system.NewServiceAssembler(logMonitor, vConfig, mode)
 	assembler.Register(&routing.RouterServiceAssembly{})
 	assembler.Register(&cfmauth.AuthServiceAssembly{})
@@ -79,7 +85,7 @@ func Launch(shutdown <-chan struct{}) {
 		assembler.Register(&memorystore.InMemoryServiceAssembly{})
 	}
 
-	assembler.Register(natsprovision.NewNatsOrchestrationServiceAssembly(uri, bucketValue, streamValue))
+	assembler.Register(natsprovision.NewNatsOrchestrationServiceAssembly(natsclient.ClientConfig{URL: uri, Bucket: bucketValue, Auth: natsAuth}, streamValue))
 	if err := runtime.SetupTelemetry("cfm.tmanager", shutdown); err != nil {
 		logMonitor.Warnf("Error setting up telemetry: %s. Traces and metrics will not be available.", err.Error())
 	}

--- a/tmanager/natsprovision/assembly.go
+++ b/tmanager/natsprovision/assembly.go
@@ -22,8 +22,7 @@ import (
 )
 
 type natsOrchestrationServiceAssembly struct {
-	uri                 string
-	bucket              string
+	clientConfig        natsclient.ClientConfig
 	streamName          string
 	natsClient          *natsclient.NatsClient
 	orchestrationClient *natsOrchestrationClient
@@ -32,11 +31,10 @@ type natsOrchestrationServiceAssembly struct {
 	system.DefaultServiceAssembly
 }
 
-func NewNatsOrchestrationServiceAssembly(uri string, bucket string, streamName string) system.ServiceAssembly {
+func NewNatsOrchestrationServiceAssembly(clientConfig natsclient.ClientConfig, streamName string) system.ServiceAssembly {
 	return &natsOrchestrationServiceAssembly{
-		uri:        uri,
-		bucket:     bucket,
-		streamName: streamName,
+		clientConfig: clientConfig,
+		streamName:   streamName,
 	}
 }
 
@@ -53,7 +51,7 @@ func (d *natsOrchestrationServiceAssembly) Requires() []system.ServiceType {
 }
 
 func (a *natsOrchestrationServiceAssembly) Init(ctx *system.InitContext) error {
-	natsClient, err := natsclient.NewNatsClient(a.uri, a.bucket)
+	natsClient, err := natsclient.NewNatsClient(a.clientConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #86

## What this PR changes

Implements the `AuthStrategy` approach discussed in the issue: the NATS client is now constructed from a `ClientConfig` struct with a pluggable authentication strategy, replacing the previous `NewNatsClient(url, bucket, opts...)` signature.

### Supported mechanisms

| `nats.auth.method` | Strategy | Inputs |
|---|---|---|
| `none` (default) | anonymous, current behavior | — |
| `userinfo` | `nats.UserInfo` | `nats.auth.username`, `nats.auth.password` |
| `token` | `nats.Token` | `nats.auth.token` |
| `nkey` | `nats.NkeyOptionFromSeed` | `nats.auth.nkeySeedFile` |
| `credentials` | `nats.UserCredentials` | `nats.auth.credsFile` |

The strategy is resolved per component via `natsclient.AuthFromConfig` under the component's existing config prefix, so e.g. `PM_NATS_AUTH_METHOD=nkey PM_NATS_AUTH_NKEYSEEDFILE=/etc/nats/user.nk` through the standard env var mapping. File-based inputs (NKey seed, `.creds`) fit Kubernetes secret volume mounts; inline values fit secret-backed env vars. Each strategy validates its inputs at startup and fails with a descriptive error instead of an opaque connection timeout. Unknown methods are a hard startup error.

### Notes

- Without any `nats.auth.*` configuration, connections remain anonymous — existing deployments are unaffected.
- The connection resilience defaults (ping interval, reconnect-forever, retry on failed connect) are now always applied. Previously they were silently dropped as soon as any `nats.Option` was passed.
- All call sites (lifecycle agent launcher, orchestration agent launcher, pmanager and tmanager assemblies) thread a `ClientConfig` through; the assembly constructors changed accordingly.
- Integration tests run token, user/password, and NKey authentication against auth-enabled NATS test containers (plus a wrong-credentials negative test) via a new `natsfixtures.SetupNatsContainerWithAuth`. Credentials-file auth is unit-tested only, since a realistic test requires an operator-mode server setup.
- TLS is deliberately out of scope; it slots in later as another option-producing component next to `Auth` in `ClientConfig`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)