### PR TITLE
feat: token exchange configuration on siglet registration

### DIFF
--- a/agent/common/controlplane/controlplane.go
+++ b/agent/common/controlplane/controlplane.go
@@ -97,6 +97,10 @@ type DataPlaneRegistration struct {
 	TransferTypes []string `json:"transferTypes"`
 	// Endpoint is the data plane's DPS signaling endpoint the control plane sends flow events to.
 	Endpoint string `json:"endpoint"`
+	// Authorization is the optional DPS authorization profile the control plane uses to authorize
+	// signaling exchanges with this data plane. It is a flat object: "type" plus the properties of
+	// that profile. Omitted from the request when nil.
+	Authorization map[string]any `json:"authorization,omitempty"`
 }
 
 // DataPlaneRegistrationClient registers and unregisters data-plane instances with the EDC control

--- a/agent/common/controlplane/controlplane_test.go
+++ b/agent/common/controlplane/controlplane_test.go
@@ -457,6 +457,47 @@ func TestRegisterDataPlane(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "test-participant-siglet", received["dataplaneId"])
 	require.Equal(t, "http://siglet.edc-v.svc.cluster.local:8081/api/v1/test-participant/dataflows", received["endpoint"])
+	require.NotContains(t, received, "authorization", "an absent authorization profile must not be sent")
+}
+
+func TestRegisterDataPlane_WithAuthorization(t *testing.T) {
+	var received map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut && r.URL.Path == CreateParticipantURL+"/test-participant/dataplanes" {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &received))
+			w.WriteHeader(http.StatusOK)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	tp := mocks.NewMockTokenProvider(t)
+	tp.On("GetToken", mock.Anything, mock.Anything, mock.Anything).Return("token", nil)
+	client := HttpManagementAPIClient{BaseURL: server.URL, TokenProvider: tp, HttpClient: &http.Client{}}
+
+	err := client.RegisterDataPlane(t.Context(), "test-participant", DataPlaneRegistration{
+		ID:            "test-participant-siglet",
+		TransferTypes: []string{"HttpData-PULL"},
+		Endpoint:      "http://siglet.edc-v.svc.cluster.local:8081/api/v1/test-participant/dataflows",
+		Authorization: map[string]any{
+			"type":                  "oauth2_token_exchange",
+			"tokenExchangeEndpoint": "https://broker.example.com/token",
+			"issuer":                "https://broker.example.com",
+			"jwksUri":               "https://broker.example.com/.well-known/jwks.json",
+			"resource":              "test-participant",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{
+		"type":                  "oauth2_token_exchange",
+		"tokenExchangeEndpoint": "https://broker.example.com/token",
+		"issuer":                "https://broker.example.com",
+		"jwksUri":               "https://broker.example.com/.well-known/jwks.json",
+		"resource":              "test-participant",
+	}, received["authorization"])
 }
 
 func TestRegisterDataPlane_AuthError(t *testing.T) {

--- a/agent/orchestration/siglet/activity/activity.go
+++ b/agent/orchestration/siglet/activity/activity.go
@@ -13,7 +13,7 @@
 // Package activity implements the deploy/dispose activity for the Siglet data-plane agent. On deploy
 // it reads the transfer-type mappings from the cfm.dataplane VPA properties, configures them in
 // Siglet for the participant context, and registers the Siglet data-plane instance with the control
-// plane. On dispose it reverses both operations.
+// plane, optionally with a DPS authorization profile. On dispose it reverses both operations.
 package activity
 
 import (
@@ -37,6 +37,16 @@ import (
 // transfer-type mappings (transferType -> mapping) to configure in Siglet.
 const TransferTypeMappingsKey = "transferTypeMappings"
 
+// AuthorizationKey is the key in the cfm.dataplane VPA properties that opts the data-plane
+// registration into a DPS authorization profile. Its presence is what enables the profile: an object
+// carrying only the type takes every other property from the agent configuration, an absent key
+// registers the data plane without any authorization.
+const AuthorizationKey = "authorization"
+
+// authorizationType is the DPS authorization profile the agent knows how to populate, and the only
+// value accepted for the type property of the VPA authorization object.
+const authorizationType = "oauth2_token_exchange"
+
 // dataPlaneIDSuffix is appended to the participant context id to derive the data-plane instance id.
 const dataPlaneIDSuffix = "-siglet"
 
@@ -47,6 +57,20 @@ const defaultTokenSource = "provider"
 // single verb is the participant context id. It is appended to the configured Siglet signaling URL.
 const dataflowsPathTemplate = "/api/v1/%s/dataflows"
 
+// AuthorizationConfig holds the agent-level fallbacks for the data-plane authorization profile. Each
+// value is used for the corresponding property when the cfm.dataplane VPA leaves it unset.
+type AuthorizationConfig struct {
+	// TokenExchangeEndpoint is the RFC 8693 token exchange endpoint of the broker, from tokenexchange.url.
+	TokenExchangeEndpoint string
+	// Issuer is the expected iss claim of tokens minted by the broker, from tokenexchange.issuer.
+	Issuer string
+	// JwksUri is the broker's JWKS endpoint, from tokenexchange.jwksUri.
+	JwksUri string
+	// Scope is the scope requested for exchanged tokens, from tokenexchange.scope. Optional: when it
+	// is empty and the VPA sets none either, the connector falls back to its own configuration.
+	Scope string
+}
+
 type Config struct {
 	system.LogMonitor
 	// SigletSignalingURL is the base URL of the Siglet signaling API (scheme://host:port). The
@@ -54,6 +78,8 @@ type Config struct {
 	SigletSignalingURL        string
 	TransferTypeMappingClient siglet.TransferTypeMappingClient
 	DataPlaneClient           controlplane.DataPlaneRegistrationClient
+	// Authorization holds the fallbacks for the data-plane authorization profile.
+	Authorization AuthorizationConfig
 }
 
 type SigletActivityProcessor struct {
@@ -62,6 +88,7 @@ type SigletActivityProcessor struct {
 	sigletSignalingURL        string
 	transferTypeMappingClient siglet.TransferTypeMappingClient
 	dataPlaneClient           controlplane.DataPlaneRegistrationClient
+	authorization             AuthorizationConfig
 	tracer                    trace.Tracer
 }
 
@@ -71,6 +98,7 @@ func NewProcessor(config *Config) *SigletActivityProcessor {
 		sigletSignalingURL:        config.SigletSignalingURL,
 		transferTypeMappingClient: config.TransferTypeMappingClient,
 		dataPlaneClient:           config.DataPlaneClient,
+		authorization:             config.Authorization,
 		tracer:                    otel.GetTracerProvider().Tracer("cfm.agent.siglet"),
 	}
 }
@@ -100,6 +128,12 @@ func (p SigletActivityProcessor) ProcessDeploy(ctx api.ActivityContext) api.Acti
 		return api.ActivityResult{Result: api.ActivityResultComplete}
 	}
 
+	authorization, err := extractAuthorization(props)
+	if err != nil {
+		span.RecordError(err)
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error parsing data plane authorization for orchestration %s: %w", ctx.OID(), err)}
+	}
+
 	var data sigletData
 	if err := ctx.ReadValues(&data); err != nil {
 		span.RecordError(err)
@@ -108,7 +142,7 @@ func (p SigletActivityProcessor) ProcessDeploy(ctx api.ActivityContext) api.Acti
 	participantContextId := data.ParticipantContextId
 	span.SetAttributes(attribute.String("cfm.participantContextId", participantContextId))
 
-	return p.handleDeployAction(spanCtx, participantContextId, mappings)
+	return p.handleDeployAction(spanCtx, participantContextId, mappings, authorization)
 }
 
 func (p SigletActivityProcessor) ProcessDispose(ctx api.ActivityContext) api.ActivityResult {
@@ -121,7 +155,14 @@ func (p SigletActivityProcessor) ProcessDispose(ctx api.ActivityContext) api.Act
 
 // handleDeployAction configures the transfer-type mappings in Siglet (upsert) and registers the
 // Siglet data-plane instance with the control plane.
-func (p SigletActivityProcessor) handleDeployAction(ctx context.Context, participantContextId string, mappings map[string]siglet.TransferType) api.ActivityResult {
+func (p SigletActivityProcessor) handleDeployAction(ctx context.Context, participantContextId string, mappings map[string]siglet.TransferType, authorization *authorizationProperties) api.ActivityResult {
+	// Resolve the authorization profile before touching Siglet, so an incomplete profile fails the
+	// activity without leaving a half-applied transfer-type mapping behind.
+	profile, err := p.authorizationProfile(participantContextId, authorization)
+	if err != nil {
+		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: err}
+	}
+
 	// Only mappings that carry enough information to be a valid Siglet mapping are configured in
 	// Siglet; the rest are still registered as data-plane transfer types below.
 	sigletMappings := make(map[string]siglet.TransferType, len(mappings))
@@ -155,7 +196,7 @@ func (p SigletActivityProcessor) handleDeployAction(ctx context.Context, partici
 		p.monitor.Infof("No Siglet-configurable transfer type mappings for participant '%s'; registering data plane only", participantContextId)
 	}
 
-	if err := p.dataPlaneClient.RegisterDataPlane(ctx, participantContextId, p.dataPlaneRegistration(participantContextId, mappings)); err != nil {
+	if err := p.dataPlaneClient.RegisterDataPlane(ctx, participantContextId, p.dataPlaneRegistration(participantContextId, mappings, profile)); err != nil {
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("cannot register data plane in control plane: %w", err)}
 	}
 
@@ -212,6 +253,116 @@ func extractMappings(props map[string]any) (map[string]siglet.TransferType, erro
 	return mappings, nil
 }
 
+// authorizationProperties is the typed view of the authorization object in the cfm.dataplane VPA
+// properties. Type is required and selects the profile; every other property is optional on input:
+// what is not set falls back to the agent configuration, except resource which falls back to the
+// participant context id.
+type authorizationProperties struct {
+	Type                  string `json:"type"`
+	TokenExchangeEndpoint string `json:"tokenExchangeEndpoint"`
+	Issuer                string `json:"issuer"`
+	JwksUri               string `json:"jwksUri"`
+	Resource              string `json:"resource"`
+	Scope                 string `json:"scope"`
+}
+
+// extractAuthorization reads and decodes the authorization object from the data plane VPA properties.
+// It returns nil (not an error) when the properties or the authorization key are absent, which is
+// what tells the caller to register the data plane without an authorization profile.
+func extractAuthorization(props map[string]any) (*authorizationProperties, error) {
+	if props == nil {
+		return nil, nil
+	}
+	raw, ok := props[AuthorizationKey]
+	if !ok || raw == nil {
+		return nil, nil
+	}
+	// round-trip through JSON to decode the untyped property bag into typed properties
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return nil, err
+	}
+	var authorization authorizationProperties
+	if err := json.Unmarshal(encoded, &authorization); err != nil {
+		return nil, err
+	}
+	return &authorization, nil
+}
+
+// authorizationProfile resolves the DPS authorization profile registered with the data plane. The
+// profile is built when the VPA authorization object declares the supported type; each property is
+// then taken from the VPA when set and from the agent configuration otherwise, except resource, which
+// defaults to the participant context id. It returns nil when the VPA carries no authorization
+// object, and an error when the declared type is unsupported or a required property resolves to empty
+// - registering a half-populated profile would only surface later as opaque signaling failures.
+//
+// Note on resource: the control plane derives the caller identity of an incoming signaling request
+// from the token's client_id claim, falling back to sub (the resource URI), and matches it against
+// the registered dataplaneId, which is "<participantContextId>-siglet". With the default resource the
+// broker must therefore mint client_id = "<participantContextId>-siglet"; deployments whose broker
+// does not mint client_id should set resource explicitly in the VPA.
+func (p SigletActivityProcessor) authorizationProfile(participantContextId string, vpa *authorizationProperties) (map[string]any, error) {
+	if vpa == nil {
+		return nil, nil
+	}
+
+	if profileType := strings.TrimSpace(vpa.Type); profileType != authorizationType {
+		if profileType == "" {
+			return nil, fmt.Errorf("data plane authorization property 'type' is not set in the %s VPA: the only supported type is '%s'", model.DataPlaneType, authorizationType)
+		}
+		return nil, fmt.Errorf("unsupported data plane authorization type '%s' in the %s VPA: the only supported type is '%s'", profileType, model.DataPlaneType, authorizationType)
+	}
+
+	endpoint := firstNonEmpty(vpa.TokenExchangeEndpoint, p.authorization.TokenExchangeEndpoint)
+	issuer := firstNonEmpty(vpa.Issuer, p.authorization.Issuer)
+	jwksUri := firstNonEmpty(vpa.JwksUri, p.authorization.JwksUri)
+	resource := firstNonEmpty(vpa.Resource, participantContextId)
+	scope := firstNonEmpty(vpa.Scope, p.authorization.Scope)
+
+	required := []struct {
+		property  string
+		value     string
+		configKey string
+	}{
+		{"tokenExchangeEndpoint", endpoint, "tokenexchange.url"},
+		{"issuer", issuer, "tokenexchange.issuer"},
+		{"jwksUri", jwksUri, "tokenexchange.jwksUri"},
+		{"resource", resource, ""},
+	}
+	for _, r := range required {
+		if r.value == "" {
+			if r.configKey == "" {
+				return nil, fmt.Errorf("data plane authorization property '%s' is not set in the %s VPA", r.property, model.DataPlaneType)
+			}
+			return nil, fmt.Errorf("data plane authorization property '%s' is not set in the %s VPA and no fallback is configured (%s)", r.property, model.DataPlaneType, r.configKey)
+		}
+	}
+
+	profile := map[string]any{
+		"type":                  authorizationType,
+		"tokenExchangeEndpoint": endpoint,
+		"issuer":                issuer,
+		"jwksUri":               jwksUri,
+		"resource":              resource,
+	}
+	// scope is optional end to end: when neither the VPA nor the agent sets it, the connector falls
+	// back to its own configured default scope.
+	if scope != "" {
+		profile["scope"] = scope
+	}
+	return profile, nil
+}
+
+// firstNonEmpty returns the first of the given values that is not blank, trimmed, or "" if all are.
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
 // isSigletConfigurable reports whether a transfer-type mapping carries enough information to be
 // configured in Siglet: an endpoint type plus either a static endpoint or at least one endpoint
 // mapping. A mapping that only names its transfer type is still registered as a data-plane transfer
@@ -225,8 +376,8 @@ func isSigletConfigurable(tt siglet.TransferType) bool {
 
 // dataPlaneRegistration builds the control-plane registration for the Siglet data plane. The transfer
 // types are derived from the configured mappings and the endpoint is the participant-scoped Siglet
-// DPS signaling endpoint.
-func (p SigletActivityProcessor) dataPlaneRegistration(participantContextId string, mappings map[string]siglet.TransferType) controlplane.DataPlaneRegistration {
+// DPS signaling endpoint. The authorization profile is nil unless the VPA asked for one.
+func (p SigletActivityProcessor) dataPlaneRegistration(participantContextId string, mappings map[string]siglet.TransferType, authorization map[string]any) controlplane.DataPlaneRegistration {
 	transferTypes := make([]string, 0, len(mappings))
 	for transferType := range mappings {
 		transferTypes = append(transferTypes, transferType)
@@ -235,6 +386,7 @@ func (p SigletActivityProcessor) dataPlaneRegistration(participantContextId stri
 		ID:            dataPlaneID(participantContextId),
 		TransferTypes: transferTypes,
 		Endpoint:      p.dataPlaneEndpoint(participantContextId),
+		Authorization: authorization,
 	}
 }
 

--- a/agent/orchestration/siglet/activity/activity_test.go
+++ b/agent/orchestration/siglet/activity/activity_test.go
@@ -36,6 +36,10 @@ func WithDataPlane(client controlplane.DataPlaneRegistrationClient) ConfigOption
 	return func(config *Config) { config.DataPlaneClient = client }
 }
 
+func WithAuthorization(authorization AuthorizationConfig) ConfigOptions {
+	return func(config *Config) { config.Authorization = authorization }
+}
+
 func validConfig(opts ...ConfigOptions) *Config {
 	c := Config{
 		LogMonitor:                system.NoopMonitor{},
@@ -60,6 +64,32 @@ func mappingsProps() map[string]any {
 			},
 		},
 	}
+}
+
+// configuredAuthorization is the agent-level fallback used by the authorization tests.
+func configuredAuthorization() AuthorizationConfig {
+	return AuthorizationConfig{
+		TokenExchangeEndpoint: "https://broker.example.com/token",
+		Issuer:                "https://broker.example.com",
+		JwksUri:               "https://broker.example.com/.well-known/jwks.json",
+	}
+}
+
+// propsWithAuthorization returns the transfer-type mapping properties plus an authorization object.
+func propsWithAuthorization(authorization map[string]any) map[string]any {
+	props := mappingsProps()
+	props[AuthorizationKey] = authorization
+	return props
+}
+
+// tokenExchangeAuthorization returns a VPA authorization object declaring the supported type, plus
+// the given property overrides.
+func tokenExchangeAuthorization(overrides map[string]any) map[string]any {
+	authorization := map[string]any{"type": "oauth2_token_exchange"}
+	for key, value := range overrides {
+		authorization[key] = value
+	}
+	return authorization
 }
 
 // validVpaData returns a VPA data slice with a single dataplane entry. If properties is nil, the
@@ -252,6 +282,138 @@ func TestSiglet_Deploy_ControlPlaneError(t *testing.T) {
 
 	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
 	assert.ErrorContains(t, result.Error, "cp boom")
+}
+
+func TestSiglet_Deploy_NoAuthorizationInVpa_RegistersWithoutProfile(t *testing.T) {
+	dpClient := &MockDataPlaneClient{}
+	processor := NewProcessor(validConfig(WithDataPlane(dpClient), WithAuthorization(configuredAuthorization())))
+
+	result := processor.ProcessDeploy(newContext(processingDataWith(validVpaData(mappingsProps())), api.DeployDiscriminator))
+
+	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)
+	assert.NoError(t, result.Error)
+	assert.True(t, dpClient.registered)
+	assert.Nil(t, dpClient.lastRegistration.Authorization, "an absent authorization key must not register a profile")
+}
+
+func TestSiglet_Deploy_TypeOnlyAuthorization_UsesConfiguredFallbacks(t *testing.T) {
+	dpClient := &MockDataPlaneClient{}
+	processor := NewProcessor(validConfig(WithDataPlane(dpClient), WithAuthorization(configuredAuthorization())))
+
+	props := propsWithAuthorization(tokenExchangeAuthorization(nil))
+	result := processor.ProcessDeploy(newContext(processingDataWith(validVpaData(props)), api.DeployDiscriminator))
+
+	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)
+	assert.NoError(t, result.Error)
+	require.NotNil(t, dpClient.lastRegistration.Authorization)
+	assert.Equal(t, map[string]any{
+		"type":                  "oauth2_token_exchange",
+		"tokenExchangeEndpoint": "https://broker.example.com/token",
+		"issuer":                "https://broker.example.com",
+		"jwksUri":               "https://broker.example.com/.well-known/jwks.json",
+		"resource":              "participant-1",
+	}, dpClient.lastRegistration.Authorization)
+	assert.NotContains(t, dpClient.lastRegistration.Authorization, "scope", "an unset scope must be omitted")
+}
+
+func TestSiglet_Deploy_Authorization_UsesConfiguredScope(t *testing.T) {
+	dpClient := &MockDataPlaneClient{}
+	authorization := configuredAuthorization()
+	authorization.Scope = "signaling:dataflow"
+	processor := NewProcessor(validConfig(WithDataPlane(dpClient), WithAuthorization(authorization)))
+
+	props := propsWithAuthorization(tokenExchangeAuthorization(nil))
+	result := processor.ProcessDeploy(newContext(processingDataWith(validVpaData(props)), api.DeployDiscriminator))
+
+	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)
+	assert.Equal(t, "signaling:dataflow", dpClient.lastRegistration.Authorization["scope"])
+}
+
+func TestSiglet_Deploy_Authorization_VpaOverridesConfiguration(t *testing.T) {
+	dpClient := &MockDataPlaneClient{}
+	authorization := configuredAuthorization()
+	authorization.Scope = "configured:scope"
+	processor := NewProcessor(validConfig(WithDataPlane(dpClient), WithAuthorization(authorization)))
+
+	props := propsWithAuthorization(tokenExchangeAuthorization(map[string]any{
+		"tokenExchangeEndpoint": "https://vpa.example.com/token",
+		"issuer":                "https://vpa.example.com",
+		"jwksUri":               "https://vpa.example.com/jwks",
+		"resource":              "urn:dps:principal:participant-1",
+		"scope":                 "vpa:scope",
+	}))
+	result := processor.ProcessDeploy(newContext(processingDataWith(validVpaData(props)), api.DeployDiscriminator))
+
+	assert.Equal(t, api.ActivityResultType(api.ActivityResultComplete), result.Result)
+	assert.NoError(t, result.Error)
+	assert.Equal(t, map[string]any{
+		"type":                  "oauth2_token_exchange",
+		"tokenExchangeEndpoint": "https://vpa.example.com/token",
+		"issuer":                "https://vpa.example.com",
+		"jwksUri":               "https://vpa.example.com/jwks",
+		"resource":              "urn:dps:principal:participant-1",
+		"scope":                 "vpa:scope",
+	}, dpClient.lastRegistration.Authorization)
+}
+
+func TestSiglet_Deploy_Authorization_MissingRequiredProperty(t *testing.T) {
+	sigletClient := &MockSigletClient{}
+	dpClient := &MockDataPlaneClient{}
+	authorization := configuredAuthorization()
+	authorization.Issuer = ""
+	processor := NewProcessor(validConfig(WithSiglet(sigletClient), WithDataPlane(dpClient), WithAuthorization(authorization)))
+
+	props := propsWithAuthorization(tokenExchangeAuthorization(nil))
+	result := processor.ProcessDeploy(newContext(processingDataWith(validVpaData(props)), api.DeployDiscriminator))
+
+	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
+	require.Error(t, result.Error)
+	assert.Contains(t, result.Error.Error(), "issuer")
+	assert.Contains(t, result.Error.Error(), "tokenexchange.issuer")
+	// the profile is resolved before anything is applied, so nothing is left half-configured
+	assert.False(t, sigletClient.created, "expected no transfer type mapping to be created")
+	assert.False(t, dpClient.registered, "expected the data plane not to be registered")
+}
+
+func TestSiglet_Deploy_Authorization_UnsupportedType(t *testing.T) {
+	sigletClient := &MockSigletClient{}
+	dpClient := &MockDataPlaneClient{}
+	processor := NewProcessor(validConfig(WithSiglet(sigletClient), WithDataPlane(dpClient), WithAuthorization(configuredAuthorization())))
+
+	props := propsWithAuthorization(map[string]any{"type": "oauth2_client_credentials"})
+	result := processor.ProcessDeploy(newContext(processingDataWith(validVpaData(props)), api.DeployDiscriminator))
+
+	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
+	require.Error(t, result.Error)
+	assert.Contains(t, result.Error.Error(), "oauth2_client_credentials")
+	assert.False(t, sigletClient.created)
+	assert.False(t, dpClient.registered)
+}
+
+func TestSiglet_Deploy_Authorization_MissingType(t *testing.T) {
+	dpClient := &MockDataPlaneClient{}
+	processor := NewProcessor(validConfig(WithDataPlane(dpClient), WithAuthorization(configuredAuthorization())))
+
+	props := propsWithAuthorization(map[string]any{"issuer": "https://vpa.example.com"})
+	result := processor.ProcessDeploy(newContext(processingDataWith(validVpaData(props)), api.DeployDiscriminator))
+
+	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
+	require.Error(t, result.Error)
+	assert.Contains(t, result.Error.Error(), "'type'")
+	assert.False(t, dpClient.registered)
+}
+
+func TestSiglet_Deploy_Authorization_NotAnObject(t *testing.T) {
+	dpClient := &MockDataPlaneClient{}
+	processor := NewProcessor(validConfig(WithDataPlane(dpClient), WithAuthorization(configuredAuthorization())))
+
+	props := mappingsProps()
+	props[AuthorizationKey] = "not-an-object"
+	result := processor.ProcessDeploy(newContext(processingDataWith(validVpaData(props)), api.DeployDiscriminator))
+
+	assert.Equal(t, api.ActivityResultType(api.ActivityResultFatalError), result.Result)
+	require.Error(t, result.Error)
+	assert.False(t, dpClient.registered)
 }
 
 func TestSiglet_Dispose_HappyPath(t *testing.T) {

--- a/agent/orchestration/siglet/launcher/launcher.go
+++ b/agent/orchestration/siglet/launcher/launcher.go
@@ -35,6 +35,12 @@ const (
 	tokenExchangeURLKey    = "tokenexchange.url"
 	tokenFilePathKey       = "tokenexchange.tokenFilePath"
 	audienceKey            = "tokenexchange.audience"
+	// Fallbacks for the data-plane authorization profile, used for the properties a cfm.dataplane VPA
+	// leaves unset. Optional: they are only needed when a VPA opts into an authorization profile, so a
+	// missing value is reported by the deploy activity rather than at launch.
+	issuerKey  = "tokenexchange.issuer"
+	jwksURIKey = "tokenexchange.jwksUri"
+	scopeKey   = "tokenexchange.scope"
 )
 
 func LaunchAndWaitSignal(shutdown <-chan struct{}) {
@@ -56,6 +62,9 @@ func LaunchAndWaitSignal(shutdown <-chan struct{}) {
 			tokenExchangeURL := ctx.Config.GetString(tokenExchangeURLKey)
 			tokenFilePath := ctx.Config.GetString(tokenFilePathKey)
 			audience := ctx.Config.GetString(audienceKey)
+			issuer := ctx.Config.GetString(issuerKey)
+			jwksURI := ctx.Config.GetString(jwksURIKey)
+			scope := ctx.Config.GetString(scopeKey)
 
 			if err := runtime.CheckRequiredParams(
 				sigletManagementURLKey, sigletManagementURL,
@@ -81,6 +90,12 @@ func LaunchAndWaitSignal(shutdown <-chan struct{}) {
 					BaseURL:       cpURL,
 					TokenProvider: provider,
 					HttpClient:    &httpClient,
+				},
+				Authorization: activity.AuthorizationConfig{
+					TokenExchangeEndpoint: tokenExchangeURL + "/token",
+					Issuer:                issuer,
+					JwksUri:               jwksURI,
+					Scope:                 scope,
 				},
 			})
 		},


### PR DESCRIPTION
token exchange configuration on siglet registration. 

In the VPA of type dataplane It can be activated with this configuration:

```
"cfm.dataplane": {
      "authorization": {
        "type": "oauth2_token_exchange"
      }
}
```
