### PR TITLE
feat: configurable client mappings

### DIFF
--- a/agent/orchestration/jwtletagent/activity/activity.go
+++ b/agent/orchestration/jwtletagent/activity/activity.go
@@ -54,21 +54,24 @@ const (
 	scopeSignaling = "signaling"
 )
 
-// vaultServiceAccount is a workload ServiceAccount that exchanges its projected token for a
+// ClientMapping names a workload ServiceAccount that exchanges its projected token for a
 // participant-scoped token, together with the scopes its resource mapping grants.
-type vaultServiceAccount struct {
-	name   string
-	scopes []string
+type ClientMapping struct {
+	// Name is the bare ServiceAccount name; the client identifier jwtlet sees is built from it and
+	// Config.ServiceAccountNamespace.
+	Name   string   `json:"name" mapstructure:"name"`
+	Scopes []string `json:"scopes" mapstructure:"scopes"`
 }
 
-// vaultServiceAccounts are the workload ServiceAccounts that exchange their projected token for a
-// participant-scoped token. The resulting token's `sub` is the participant context id, which scopes
-// the workload to that participant's vault partition. Every workload gets scopeVaultRead; the control
-// plane additionally gets scopeSignaling for DPS signaling with the data plane.
-var vaultServiceAccounts = []vaultServiceAccount{
-	{name: "controlplane", scopes: []string{scopeVaultRead, scopeSignaling}},
-	{name: "identityhub", scopes: []string{scopeVaultRead}},
-	{name: "siglet-sa", scopes: []string{scopeVaultRead}},
+// defaultClientMappings are the client mappings used when none are configured. The workloads they
+// name exchange their projected token for a participant-scoped token whose `sub` is the participant
+// context id, which scopes the workload to that participant's vault partition. Every workload gets
+// scopeVaultRead; the control plane additionally gets scopeSignaling for DPS signaling with the
+// data plane.
+var defaultClientMappings = []ClientMapping{
+	{Name: "controlplane", Scopes: []string{scopeVaultRead, scopeSignaling}},
+	{Name: "identityhub", Scopes: []string{scopeVaultRead}},
+	{Name: "siglet-sa", Scopes: []string{scopeVaultRead}},
 }
 
 // agentScopes is the exact set of narrow scopes the CFM agents request against a participant
@@ -96,13 +99,13 @@ type TokenExchangeActivityProcessor struct {
 	Audience           string
 	ManagementBasePath string
 
-	clientIdentifier    string
-	vaultClientMappings []vaultClientMapping
+	clientIdentifier string
+	resolvedMappings []resolvedMapping
 }
 
-// vaultClientMapping is a resolved vaultServiceAccount: the client identifier jwtlet sees for the
-// workload, plus the scopes its resource mapping grants.
-type vaultClientMapping struct {
+// resolvedMapping is a ClientMapping with its ServiceAccount name resolved to the client identifier
+// jwtlet sees for the workload.
+type resolvedMapping struct {
 	clientIdentifier string
 	scopes           []string
 }
@@ -133,26 +136,35 @@ type Config struct {
 	// ServiceAccountNamespace is the Kubernetes namespace the CFM workload ServiceAccounts live in,
 	// used to build the client identifiers of the resource mappings.
 	ServiceAccountNamespace string
+	// ClientMappings are the workload ServiceAccounts that exchange their projected token for a
+	// participant-scoped token, and the scopes each one gets (config key `clientmappings`). When
+	// empty, defaultClientMappings is used, so a deployment that does not configure the key keeps
+	// the built-in mappings.
+	ClientMappings []ClientMapping
 }
 
 func NewProcessor(config *Config) *TokenExchangeActivityProcessor {
-	vaultClientMappings := make([]vaultClientMapping, 0, len(vaultServiceAccounts))
-	for _, sa := range vaultServiceAccounts {
-		vaultClientMappings = append(vaultClientMappings, vaultClientMapping{
-			clientIdentifier: serviceAccountIdentifier(config.ServiceAccountNamespace, sa.name),
-			scopes:           sa.scopes,
+	mappings := config.ClientMappings
+	if len(mappings) == 0 {
+		mappings = defaultClientMappings
+	}
+	resolvedMappings := make([]resolvedMapping, 0, len(mappings))
+	for _, mapping := range mappings {
+		resolvedMappings = append(resolvedMappings, resolvedMapping{
+			clientIdentifier: serviceAccountIdentifier(config.ServiceAccountNamespace, mapping.Name),
+			scopes:           mapping.Scopes,
 		})
 	}
 	return &TokenExchangeActivityProcessor{
-		Monitor:             config.LogMonitor,
-		TokenProvider:       config.TokenProvider,
-		HttpClient:          config.HttpClient,
-		tracer:              otel.GetTracerProvider().Tracer("cfm.agent.jwtlet"),
-		ManagementBasePath:  config.ManagementBasePath,
-		TokenFilePath:       config.TokenFilePath,
-		Audience:            config.Audience,
-		clientIdentifier:    serviceAccountIdentifier(config.ServiceAccountNamespace, agentsServiceAccount),
-		vaultClientMappings: vaultClientMappings,
+		Monitor:            config.LogMonitor,
+		TokenProvider:      config.TokenProvider,
+		HttpClient:         config.HttpClient,
+		tracer:             otel.GetTracerProvider().Tracer("cfm.agent.jwtlet"),
+		ManagementBasePath: config.ManagementBasePath,
+		TokenFilePath:      config.TokenFilePath,
+		Audience:           config.Audience,
+		clientIdentifier:   serviceAccountIdentifier(config.ServiceAccountNamespace, agentsServiceAccount),
+		resolvedMappings:   resolvedMappings,
 	}
 }
 
@@ -194,24 +206,26 @@ func (p TokenExchangeActivityProcessor) ProcessDeploy(ctx api.ActivityContext) a
 	}
 	mapSpan.AddEvent("Created CFM agents resource mapping")
 
-	// the control plane and identity hub must be able to exchange their token for a participant-scoped
-	// token used to authenticate against Vault (resource = participant context id). The control plane
-	// additionally needs the signaling scope to authorize DPS exchanges with the data plane.
-	for _, mapping := range p.vaultClientMappings {
-		vm := resourceMapping{
+	// the participant's workloads must be able to exchange their token for a participant-scoped token
+	// used to authenticate against Vault (resource = participant context id). Which workloads these
+	// are, and the scopes they get, comes from the configured client mappings (defaultClientMappings
+	// when unconfigured, where the control plane additionally gets the signaling scope to authorize
+	// DPS exchanges with the data plane).
+	for _, mapping := range p.resolvedMappings {
+		wm := resourceMapping{
 			ClientIdentifier:   mapping.clientIdentifier,
 			ParticipantContext: participantContextID,
 			Scopes:             mapping.scopes,
 			Audiences:          []string{p.Audience},
 		}
-		p.Monitor.Debugf("Creating vault resource mapping for %s -> %s", mapping.clientIdentifier, participantContextID)
-		if err := p.post(mapCtx, "/api/v1/mappings", vm); err != nil {
+		p.Monitor.Debugf("Creating workload resource mapping for %s -> %s", mapping.clientIdentifier, participantContextID)
+		if err := p.post(mapCtx, "/api/v1/mappings", wm); err != nil {
 			mapSpan.RecordError(err)
 			mapSpan.End()
-			return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error creating vault resource mapping for %s: %w", mapping.clientIdentifier, err)}
+			return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error creating resource mapping for %s: %w", mapping.clientIdentifier, err)}
 		}
 	}
-	mapSpan.AddEvent("Created vault resource mappings")
+	mapSpan.AddEvent("Created workload resource mappings")
 	mapSpan.End()
 
 	// step 2: verify the token exchange works for the new participant context. Requesting the
@@ -259,10 +273,10 @@ func (p TokenExchangeActivityProcessor) ProcessDispose(ctx api.ActivityContext) 
 		return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error deleting resource mapping: %w", err)}
 	}
 
-	for _, mapping := range p.vaultClientMappings {
+	for _, mapping := range p.resolvedMappings {
 		if err := p.delete(spanCtx, fmt.Sprintf("/api/v1/mappings/%s/%s", mapping.clientIdentifier, participantContextID)); err != nil {
 			span.RecordError(err)
-			return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error deleting vault resource mapping for %s: %w", mapping.clientIdentifier, err)}
+			return api.ActivityResult{Result: api.ActivityResultFatalError, Error: fmt.Errorf("error deleting resource mapping for %s: %w", mapping.clientIdentifier, err)}
 		}
 	}
 	span.AddEvent("Deleted resource mappings")

--- a/agent/orchestration/jwtletagent/activity/activity_test.go
+++ b/agent/orchestration/jwtletagent/activity/activity_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -50,7 +51,10 @@ func stubToken() string {
 	return "header." + payload + ".signature"
 }
 
-func newProcessorForTest(t *testing.T, tp *fakeTokenProvider, mappingsBase string) *TokenExchangeActivityProcessor {
+// newProcessorForTest builds a processor against the given mappings endpoint. Passing no
+// clientMappings leaves Config.ClientMappings empty, which is what an unconfigured deployment looks
+// like and therefore exercises the defaultClientMappings fallback.
+func newProcessorForTest(t *testing.T, tp *fakeTokenProvider, mappingsBase string, clientMappings ...ClientMapping) *TokenExchangeActivityProcessor {
 	t.Helper()
 	tokenFile := filepath.Join(t.TempDir(), "token")
 	require.NoError(t, os.WriteFile(tokenFile, []byte("workload-token"), 0o600))
@@ -63,6 +67,7 @@ func newProcessorForTest(t *testing.T, tp *fakeTokenProvider, mappingsBase strin
 		TokenFilePath:           tokenFile,
 		Audience:                "test-audience",
 		ServiceAccountNamespace: "test-ns",
+		ClientMappings:          clientMappings,
 	})
 }
 
@@ -117,7 +122,7 @@ func TestProcessDeploy_UsesConfiguredNamespace(t *testing.T) {
 }
 
 // TestProcessDeploy_MapsPerServiceAccountScopes asserts that each workload ServiceAccount gets the
-// scopes its vaultServiceAccounts entry declares, rather than one scope set shared by all of them:
+// scopes its defaultClientMappings entry declares, rather than one scope set shared by all of them:
 // every workload needs the vault read scope, and the control plane additionally needs the signaling
 // scope to authorize DPS exchanges with the data plane.
 func TestProcessDeploy_MapsPerServiceAccountScopes(t *testing.T) {
@@ -162,4 +167,65 @@ func TestProcessDeploy_FailsWhenScopeHasNoMapping(t *testing.T) {
 	require.Error(t, result.Error)
 	assert.Contains(t, result.Error.Error(), "token exchange")
 	assert.Equal(t, strings.Join(agentScopes, " "), tp.requestedScopes[0])
+}
+
+// TestProcessDeploy_ConfiguredClientMappingsReplaceDefaults asserts that a configured client mapping
+// list fully replaces the built-in defaults, so an operator can rename, re-scope or drop a built-in
+// workload. The cfm-agents mapping is not part of that list and must still be created.
+func TestProcessDeploy_ConfiguredClientMappingsReplaceDefaults(t *testing.T) {
+	scopesByIdentifier := map[string][]string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var rm resourceMapping
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&rm))
+		scopesByIdentifier[rm.ClientIdentifier] = rm.Scopes
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tp := &fakeTokenProvider{token: stubToken()}
+	processor := newProcessorForTest(t, tp, server.URL,
+		ClientMapping{Name: "custom-cp", Scopes: []string{"read", "signaling"}},
+		ClientMapping{Name: "custom-ih", Scopes: []string{"read"}},
+	)
+
+	result := processor.ProcessDeploy(newDeployContext())
+
+	require.EqualValues(t, api.ActivityResultComplete, result.Result, "expected deploy to complete, got error: %v", result.Error)
+	assert.Equal(t, map[string][]string{
+		"system:serviceaccount:test-ns:cfm-agents": agentScopes,
+		"system:serviceaccount:test-ns:custom-cp":  {"read", "signaling"},
+		"system:serviceaccount:test-ns:custom-ih":  {"read"},
+	}, scopesByIdentifier, "configured client mappings should replace the defaults entirely")
+}
+
+// TestProcessDispose_DeletesConfiguredClientMappings asserts that dispose tears down exactly the
+// mappings deploy created, so a configured list does not leak resource mappings in jwtlet.
+func TestProcessDispose_DeletesConfiguredClientMappings(t *testing.T) {
+	var deleted []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deleted = append(deleted, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tp := &fakeTokenProvider{token: stubToken()}
+	processor := newProcessorForTest(t, tp, server.URL,
+		ClientMapping{Name: "custom-cp", Scopes: []string{"read"}},
+	)
+
+	ctx := newDeployContext()
+	require.EqualValues(t, api.ActivityResultComplete, processor.ProcessDeploy(ctx).Result)
+
+	participantContextID, ok := ctx.Value(participantContextIDKey)
+	require.True(t, ok)
+
+	result := processor.ProcessDispose(ctx)
+
+	require.EqualValues(t, api.ActivityResultComplete, result.Result, "expected dispose to complete, got error: %v", result.Error)
+	assert.Equal(t, []string{
+		fmt.Sprintf("/api/v1/mappings/system:serviceaccount:test-ns:cfm-agents/%v", participantContextID),
+		fmt.Sprintf("/api/v1/mappings/system:serviceaccount:test-ns:custom-cp/%v", participantContextID),
+	}, deleted)
 }

--- a/agent/orchestration/jwtletagent/launcher/launcher.go
+++ b/agent/orchestration/jwtletagent/launcher/launcher.go
@@ -15,6 +15,8 @@
 package launcher
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/eclipse-cfm/cfm/agent/orchestration/jwtletagent/activity"
@@ -25,6 +27,7 @@ import (
 	"github.com/eclipse-cfm/cfm/common/tokenexchange"
 	"github.com/eclipse-cfm/cfm/pmanager/api"
 	"github.com/eclipse-cfm/cfm/pmanager/natsagent"
+	"github.com/spf13/viper"
 )
 
 const (
@@ -35,6 +38,10 @@ const (
 	audienceKey         = "tokenexchange.audience"
 	namespaceKey        = "serviceaccount.namespace"
 	defaultNamespace    = "edc-v"
+	// clientMappingsKey optionally overrides the workload ServiceAccounts that get a
+	// participant-scoped resource mapping. When unset, the activity falls back to its built-in
+	// defaults. See parseClientMappings for the accepted forms.
+	clientMappingsKey = "clientmappings"
 )
 
 func LaunchAndWaitSignal(shutdown <-chan struct{}) {
@@ -61,6 +68,11 @@ func LaunchAndWaitSignal(shutdown <-chan struct{}) {
 				panic(err)
 			}
 
+			clientMappings, err := parseClientMappings(ctx.Config)
+			if err != nil {
+				panic(err)
+			}
+
 			provider := tokenexchange.NewTokenExchangeProvider(
 				tokenFilePath,
 				tokenexchange.WithTokenExchangeUrl(tokenExchangeURL),
@@ -76,8 +88,71 @@ func LaunchAndWaitSignal(shutdown <-chan struct{}) {
 				Audience:                audience,
 				ManagementBasePath:      managementBasePath,
 				ServiceAccountNamespace: namespace,
+				ClientMappings:          clientMappings,
 			})
 		},
 	}
 	natsagent.LaunchAgent(shutdown, config)
+}
+
+// parseClientMappings reads the optional `clientmappings` key, which overrides the workload
+// ServiceAccounts that get a participant-scoped resource mapping and the scopes each one gets. Two
+// forms are accepted.
+//
+// A structured list, for deployments that mount a configuration file:
+//
+//	clientmappings:
+//	  - name: controlplane
+//	    scopes: [read, signaling]
+//
+// Or the same list as JSON, so it fits in a single environment variable. viper cannot decode a list
+// of structs out of the environment on its own — AutomaticEnv is a lookup-time fallback, so
+// UnmarshalKey only ever sees the raw string — hence the explicit json.Unmarshal here:
+//
+//	JWTLETAGENT_CLIENTMAPPINGS='[{"name":"controlplane","scopes":["read","signaling"]}]'
+//
+// A configured list fully replaces the built-in defaults. Returns nil when the key is unset, which
+// makes the activity fall back to those defaults. Note viper treats an empty environment variable as
+// unset, so JWTLETAGENT_CLIENTMAPPINGS="" also falls back.
+func parseClientMappings(v *viper.Viper) ([]activity.ClientMapping, error) {
+	if !v.IsSet(clientMappingsKey) {
+		return nil, nil
+	}
+
+	var mappings []activity.ClientMapping
+	if raw, ok := v.Get(clientMappingsKey).(string); ok {
+		if err := json.Unmarshal([]byte(raw), &mappings); err != nil {
+			return nil, fmt.Errorf("error reading %s: %q is not a JSON list of client mappings: %w", clientMappingsKey, raw, err)
+		}
+	} else if err := v.UnmarshalKey(clientMappingsKey, &mappings); err != nil {
+		return nil, fmt.Errorf("error reading %s: %w", clientMappingsKey, err)
+	}
+
+	if err := validateClientMappings(mappings); err != nil {
+		return nil, err
+	}
+	return mappings, nil
+}
+
+// validateClientMappings rejects configurations that would leave a participant's workloads without a
+// usable resource mapping. Failing at launch surfaces the misconfiguration once, instead of once per
+// participant deployment.
+func validateClientMappings(mappings []activity.ClientMapping) error {
+	if len(mappings) == 0 {
+		return fmt.Errorf("error reading %s: no client mappings configured; remove the key to use the defaults", clientMappingsKey)
+	}
+	seen := make(map[string]struct{}, len(mappings))
+	for _, mapping := range mappings {
+		if mapping.Name == "" {
+			return fmt.Errorf("error reading %s: service account name is empty", clientMappingsKey)
+		}
+		if len(mapping.Scopes) == 0 {
+			return fmt.Errorf("error reading %s: service account %q has no scopes", clientMappingsKey, mapping.Name)
+		}
+		if _, duplicate := seen[mapping.Name]; duplicate {
+			return fmt.Errorf("error reading %s: service account %q is mapped more than once", clientMappingsKey, mapping.Name)
+		}
+		seen[mapping.Name] = struct{}{}
+	}
+	return nil
 }

--- a/agent/orchestration/jwtletagent/launcher/launcher_test.go
+++ b/agent/orchestration/jwtletagent/launcher/launcher_test.go
@@ -1,0 +1,126 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package launcher
+
+import (
+	"testing"
+
+	"github.com/eclipse-cfm/cfm/agent/orchestration/jwtletagent/activity"
+	"github.com/eclipse-cfm/cfm/common/fixtures"
+	"github.com/eclipse-cfm/cfm/common/system"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseClientMappings_UnsetFallsBackToDefaults asserts that an unconfigured deployment yields no
+// client mappings, which is what makes the activity fall back to its built-in defaults.
+func TestParseClientMappings_UnsetFallsBackToDefaults(t *testing.T) {
+	mappings, err := parseClientMappings(viper.New())
+
+	require.NoError(t, err)
+	assert.Nil(t, mappings)
+}
+
+// TestParseClientMappings_StructuredList covers the config-file form, where the key holds a list of
+// maps rather than a string.
+func TestParseClientMappings_StructuredList(t *testing.T) {
+	v := viper.New()
+	v.Set(clientMappingsKey, []map[string]any{
+		{"name": "controlplane", "scopes": []string{"read", "signaling"}},
+		{"name": "identityhub", "scopes": []string{"read"}},
+	})
+
+	mappings, err := parseClientMappings(v)
+
+	require.NoError(t, err)
+	assert.Equal(t, []activity.ClientMapping{
+		{Name: "controlplane", Scopes: []string{"read", "signaling"}},
+		{Name: "identityhub", Scopes: []string{"read"}},
+	}, mappings)
+}
+
+// TestParseClientMappings_JSONString covers the single-value form, which is how the key is supplied
+// through an environment variable.
+func TestParseClientMappings_JSONString(t *testing.T) {
+	v := viper.New()
+	v.Set(clientMappingsKey, `[{"name":"controlplane","scopes":["read","signaling"]},{"name":"identityhub","scopes":["read"]}]`)
+
+	mappings, err := parseClientMappings(v)
+
+	require.NoError(t, err)
+	assert.Equal(t, []activity.ClientMapping{
+		{Name: "controlplane", Scopes: []string{"read", "signaling"}},
+		{Name: "identityhub", Scopes: []string{"read"}},
+	}, mappings)
+}
+
+// TestParseClientMappings_FromEnvironment asserts the key is reachable through a single environment
+// variable resolved by the real config loader, which is how the agent is deployed.
+func TestParseClientMappings_FromEnvironment(t *testing.T) {
+	fixtures.IsolateConfig(t)
+	t.Setenv("JWTLETAGENT_CLIENTMAPPINGS", `[{"name":"controlplane","scopes":["read","signaling"]},{"name":"siglet-sa","scopes":["read"]}]`)
+
+	mappings, err := parseClientMappings(system.LoadConfigOrPanic("jwtletagent"))
+
+	require.NoError(t, err)
+	assert.Equal(t, []activity.ClientMapping{
+		{Name: "controlplane", Scopes: []string{"read", "signaling"}},
+		{Name: "siglet-sa", Scopes: []string{"read"}},
+	}, mappings)
+}
+
+// TestParseClientMappings_EmptyEnvironmentValueFallsBack asserts an empty environment variable is
+// treated as unset rather than as an empty list, so it falls back to the defaults instead of failing.
+func TestParseClientMappings_EmptyEnvironmentValueFallsBack(t *testing.T) {
+	fixtures.IsolateConfig(t)
+	t.Setenv("JWTLETAGENT_CLIENTMAPPINGS", "")
+
+	mappings, err := parseClientMappings(system.LoadConfigOrPanic("jwtletagent"))
+
+	require.NoError(t, err)
+	assert.Nil(t, mappings)
+}
+
+// TestParseClientMappings_Invalid asserts misconfigurations fail at launch, where they are reported
+// once, rather than per participant deployment.
+func TestParseClientMappings_Invalid(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       any
+		errContains string
+	}{
+		{"not json", "controlplane:read", "is not a JSON list of client mappings"},
+		{"json object rather than list", `{"name":"controlplane","scopes":["read"]}`, "is not a JSON list of client mappings"},
+		{"no scopes", `[{"name":"controlplane"}]`, `"controlplane" has no scopes`},
+		{"empty name", `[{"scopes":["read"]}]`, "service account name is empty"},
+		{"duplicate name", `[{"name":"cp","scopes":["read"]},{"name":"cp","scopes":["write"]}]`, "mapped more than once"},
+		{"empty json list", "[]", "no client mappings configured"},
+		{"empty structured list", []map[string]any{}, "no client mappings configured"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			v := viper.New()
+			v.Set(clientMappingsKey, test.value)
+
+			mappings, err := parseClientMappings(v)
+
+			require.Error(t, err)
+			assert.Nil(t, mappings)
+			assert.Contains(t, err.Error(), clientMappingsKey)
+			assert.Contains(t, err.Error(), test.errContains)
+		})
+	}
+}


### PR DESCRIPTION

Add optional configuration for client mappings in jwtlet. When extending the core platform it may be useful to have custom client mappings for jwtlet when adding additional components to the platform